### PR TITLE
Add scripts to configure GitHub repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Collection of scripts to configure Software as a Service applications we use.
 
-## Sentry
+## [Sentry](/sentry)
 
 Tool to create and manage lots of applications in Sentry
+
+## [GitHub](/github)
+
+Tool to make sure all GOV.UK repos have the same settings and webhooks.

--- a/github/.rspec
+++ b/github/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/github/Gemfile
+++ b/github/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'octokit'
+gem 'rake'
+gem 'rspec'
+gem 'webmock'

--- a/github/Gemfile.lock
+++ b/github/Gemfile.lock
@@ -1,0 +1,49 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
+    hashdiff (0.3.4)
+    multipart-post (2.0.0)
+    octokit (4.7.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    public_suffix (3.0.0)
+    rake (12.1.0)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
+    safe_yaml (1.0.4)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    webmock (3.0.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  octokit
+  rake
+  rspec
+  webmock
+
+BUNDLED WITH
+   1.15.1

--- a/github/README.md
+++ b/github/README.md
@@ -1,0 +1,10 @@
+# GOV.UK GitHub Config
+
+Tools to make sure all of our repos have the same settings.
+
+## Tasks
+
+### `rake configure_repos`
+
+Will update the relevant settings, webhooks and branch protections for all alphagov
+repos tagged with the [topic govuk](https://github.com/search?q=topic%3Agovuk+org%3Aalphagov+fork%3Atrue).

--- a/github/Rakefile
+++ b/github/Rakefile
@@ -1,0 +1,20 @@
+require_relative 'lib/configure_repos'
+
+desc "Configure the repos with correct settings and branch protection"
+task :configure_repos do
+  ConfigureRepos.new.configure!
+end
+
+desc "Remove old webhooks"
+task :remove_old_webhooks do
+  HOOKS_TO_DELETE = %w[
+    https://snyk.io/webhook/github
+  ]
+
+  repos.map do |repo|
+    client.hooks(repo).each do |hook|
+      next unless HOOKS_TO_DELETE.include?(hook.config.url)
+      client.remove_hook(repo, hook.id)
+    end
+  end
+end

--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -1,0 +1,66 @@
+class ConfigureRepo
+  attr_reader :repo, :client
+
+  def initialize(repo, client)
+    @repo = repo
+    @client = client
+  end
+
+  def configure!
+    puts "Updating #{repo}"
+    update_repo_settings
+    protect_branch
+    update_webhooks
+    puts "√ #{repo}"
+  end
+
+private
+
+  def update_repo_settings
+    client.edit_repository(
+      repo,
+      allow_merge_commit: true,
+      allow_squash_merge: false,
+      allow_rebase_merge: false,
+    )
+  end
+
+  def protect_branch
+    client.protect_branch(
+      repo,
+      "master",
+      {
+        enforce_admins: true,
+        required_status_checks: {
+          strict: false, # "Require branches to be up to date before merging"
+          contexts: ["continuous-integration/jenkins/branch"]
+        },
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: false,
+        }
+      }
+    )
+  end
+
+  def update_webhooks
+    existing_webhooks = client.hooks(repo)
+
+    if existing_webhooks.map(&:config).map(&:url).include?("https://github-trello-poster.cloudapps.digital/payload")
+      puts "√ GitHub Trello Poster webhook exists"
+    else
+      puts "Creating GitHub Trello Poster webhook"
+      client.create_hook(
+        repo,
+        "web",
+        {
+          url: "https://github-trello-poster.cloudapps.digital/payload",
+          content_type: "json",
+        },
+        {
+          events: ["pull_request"],
+          active: true,
+        }
+      )
+    end
+  end
+end

--- a/github/lib/configure_repos.rb
+++ b/github/lib/configure_repos.rb
@@ -1,0 +1,26 @@
+require "yaml"
+require "json"
+require "octokit"
+require_relative "./configure_repo"
+
+class ConfigureRepos
+  def configure!
+    repos.each do |repo|
+      ConfigureRepo.new(repo, client).configure!
+    end
+  end
+
+private
+
+  def repos
+    client
+      .org_repos("alphagov", accept: "application/vnd.github.mercy-preview+json")
+      .select { |repo| repo.topics.to_a.include?("govuk") }
+      .map(&:full_name)
+  end
+
+  def client
+    Octokit.auto_paginate = true
+    @client ||= Octokit::Client.new(access_token: ENV.fetch("GITHUB_TOKEN"))
+  end
+end

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require_relative '../../lib/configure_repos'
+
+RSpec.describe ConfigureRepos do
+  it "Updates a repo" do
+    given_theres_a_repo
+    when_the_script_runs
+    the_repo_is_updated_with_correct_settings
+    the_repo_has_branch_protection_activated
+    the_repo_has_webhooks_configured
+  end
+
+  it "Only creates a webhook when missing" do
+    given_theres_a_repo
+    and_the_repo_has_a_github_trello_webhook_already
+    then_no_webhooks_are_changed
+  end
+
+  def given_theres_a_repo
+    stub_request(:get, "https://api.github.com/orgs/alphagov/repos?per_page=100").
+      to_return(headers: { content_type: 'application/json' }, body: [ { full_name: 'alphagov/publishing-api', topics: ["govuk"] } ].to_json)
+
+    stub_request(:get, "https://api.github.com/repos/alphagov/publishing-api/hooks?per_page=100").
+      to_return(body: [].to_json, headers: { content_type: 'application/json' })
+
+    @repo_update = stub_request(:patch, "https://api.github.com/repos/alphagov/publishing-api").to_return(body: {}.to_json)
+    @branch_protection_update = stub_request(:put, "https://api.github.com/repos/alphagov/publishing-api/branches/master/protection").to_return(body: {}.to_json)
+    @hook_creation = stub_request(:post, "https://api.github.com/repos/alphagov/publishing-api/hooks").to_return(body: {}.to_json)
+  end
+
+  def and_the_repo_has_a_github_trello_webhook_already
+    payload = [
+      { config: { url: "https://github-trello-poster.cloudapps.digital/payload" }}
+    ]
+
+    stub_request(:get, "https://api.github.com/repos/alphagov/publishing-api/hooks?per_page=100").
+      to_return(body: payload.to_json, headers: { content_type: 'application/json' })
+  end
+
+  def when_the_script_runs
+    ConfigureRepos.new.configure!
+  end
+
+  def the_repo_is_updated_with_correct_settings
+    expect(@repo_update).to have_been_requested
+  end
+
+  def the_repo_has_branch_protection_activated
+    expect(@branch_protection_update).to have_been_requested
+  end
+
+  def the_repo_has_webhooks_configured
+    expect(@hook_creation).to have_been_requested
+  end
+
+  def then_no_webhooks_are_changed
+    expect(@hook_creation).not_to have_been_requested
+  end
+end

--- a/github/spec/spec_helper.rb
+++ b/github/spec/spec_helper.rb
@@ -1,0 +1,87 @@
+require 'webmock/rspec'
+
+RSpec.configure do |config|
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+# The settings below are suggested to provide a good initial experience
+# with RSpec, but feel free to customize to your heart's content.
+=begin
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  config.disable_monkey_patching!
+
+  # This setting enables warnings. It's recommended, but in some cases may
+  # be too noisy due to issues in dependencies.
+  config.warnings = true
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = "doc"
+  end
+
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+=end
+end


### PR DESCRIPTION
This adds scripts to let us configure all of GOV.UK's repos.

It can:

- Set up the correct settings (only use merge commits)
- Set up the correct branch protection (for master, require PR reviews)
- Set up the correct webhooks to the GitHub Trello Poster

There's also a task we can use to clean up webhooks, like we have for Snyk.

https://github.com/alphagov/govuk-puppet/pull/6621 adds a Jenkins job that makes this script run every day.