### PR TITLE
Don't crash when repo isn't visible

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -12,6 +12,8 @@ class ConfigureRepo
     protect_branch
     update_webhooks
     puts "√ #{repo}"
+  rescue Octokit::NotFound => e
+    puts "Could not find #{repo}. Possibly the govuk-ci user doesn't have admin access to this repo."
   end
 
 private

--- a/github/lib/configure_repos.rb
+++ b/github/lib/configure_repos.rb
@@ -10,6 +10,10 @@ class ConfigureRepos
     end
   end
 
+  def list_repos
+    puts repos.to_yaml
+  end
+
 private
 
   def repos
@@ -17,6 +21,7 @@ private
       .org_repos("alphagov", accept: "application/vnd.github.mercy-preview+json")
       .select { |repo| repo.topics.to_a.include?("govuk") }
       .map(&:full_name)
+      .sort
   end
 
   def client

--- a/github/tasks.rake
+++ b/github/tasks.rake
@@ -6,6 +6,11 @@ namespace :github do
     ConfigureRepos.new.configure!
   end
 
+  desc "List repos that the task will configure"
+  task :list_repos do
+    ConfigureRepos.new.list_repos
+  end
+
   desc "Remove old webhooks"
   task :remove_old_webhooks do
     HOOKS_TO_DELETE = %w[


### PR DESCRIPTION
If a repo has been tagged with `govuk`, but isn't in the main GOV.UK team, the authenticating user (govuk-ci, who created `GITHUB_TOKEN`) will not have permission to update the repo. This will cause a `Octokit::NotFound` error (because the user can't even see the repo).

In this case we can just skip the repo updating.
