### PR TITLE
Allow repos to be ignored

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec) do |t|
-    t.pattern = ['github/*_spec.rb']
+    t.pattern = ['github/spec/**/*_spec.rb']
   end
 
   task default: :spec
@@ -9,4 +9,4 @@ rescue LoadError
   # no rspec available
 end
 
-Dir.glob('github/tasks.rake').each { |r| load r}
+load "github/tasks.rake"

--- a/github/ignored_repos.yml
+++ b/github/ignored_repos.yml
@@ -1,0 +1,8 @@
+# Repos that should not be auto-configured
+
+# We have a process that force-pushes to this repo, which doesn't work
+# with branch protection enabled.
+- alphagov/transition-stats
+
+# Ignored for the specs
+- alphagov/ignored-for-test

--- a/github/lib/configure_repos.rb
+++ b/github/lib/configure_repos.rb
@@ -20,8 +20,13 @@ private
     client
       .org_repos("alphagov", accept: "application/vnd.github.mercy-preview+json")
       .select { |repo| repo.topics.to_a.include?("govuk") }
+      .reject { |repo| ignored_repos.include?(repo.full_name) }
       .map(&:full_name)
       .sort
+  end
+
+  def ignored_repos
+    @ignored_repos ||= YAML.load_file("#{__dir__}/../ignored_repos.yml")
   end
 
   def client

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ConfigureRepos do
 
   def given_theres_a_repo
     stub_request(:get, "https://api.github.com/orgs/alphagov/repos?per_page=100").
-      to_return(headers: { content_type: 'application/json' }, body: [ { full_name: 'alphagov/publishing-api', topics: ["govuk"] } ].to_json)
+      to_return(headers: { content_type: 'application/json' }, body: [ { full_name: 'alphagov/publishing-api', topics: ["govuk"] }, { full_name: 'alphagov/ignored-for-test', topics: ["govuk"] } ].to_json)
 
     stub_request(:get, "https://api.github.com/repos/alphagov/publishing-api/hooks?per_page=100").
       to_return(body: [].to_json, headers: { content_type: 'application/json' })

--- a/github/spec/spec_helper.rb
+++ b/github/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'webmock/rspec'
 
+ENV["GITHUB_TOKEN"] = "A_FAKE_TOKEN"
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Some repos can't have our default repo settings (transition-stats for example). This adds a YAML file with repos that should be ignored.
