### PR TITLE
Ignore alphagov/govuk-rfcs

### DIFF
--- a/github/ignored_repos.yml
+++ b/github/ignored_repos.yml
@@ -4,5 +4,8 @@
 # with branch protection enabled.
 - alphagov/transition-stats
 
+# We shouldn't enable CI for RFCs
+- alphagov/govuk-rfcs
+
 # Ignored for the specs
 - alphagov/ignored-for-test


### PR DESCRIPTION
CI on this repo doesn't make sense.