### PR TITLE
Remove govuk-rfcs and smokey from ignored repos

### DIFF
--- a/github/ignored_repos.yml
+++ b/github/ignored_repos.yml
@@ -4,11 +4,5 @@
 # with branch protection enabled.
 - alphagov/transition-stats
 
-# We shouldn't enable CI for RFCs
-- alphagov/govuk-rfcs
-
 # Ignored for the specs
 - alphagov/ignored-for-test
-
-# We don't have CI for Smokey
-- alphagov/smokey


### PR DESCRIPTION
We don't need to ignore these repos any more since https://github.com/alphagov/govuk-saas-config/pull/11 will not configure CI for them.