### PR TITLE
Ignore archived repos

### DIFF
--- a/github/lib/configure_repos.rb
+++ b/github/lib/configure_repos.rb
@@ -21,6 +21,7 @@ private
       .org_repos("alphagov", accept: "application/vnd.github.mercy-preview+json")
       .select { |repo| repo.topics.to_a.include?("govuk") }
       .reject { |repo| ignored_repos.include?(repo.full_name) }
+      .reject { |repo| repo.archived }
       .map(&:full_name)
       .sort
   end

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe ConfigureRepos do
     the_repo_has_webhooks_configured
   end
 
+  it "Doesn't update a repo if it's archived" do
+    given_theres_a_repo(archived: true)
+    and_the_repo_has_a_jenkinsfile
+    when_the_script_runs
+    then_no_webhooks_are_changed
+    the_repo_is_not_updated
+  end
+
   it "Doesn't set up CI if there is no Jenkinsfile" do
     given_theres_a_repo
     and_the_repo_does_not_have_a_jenkinsfile
@@ -28,16 +36,16 @@ RSpec.describe ConfigureRepos do
     then_no_webhooks_are_changed
   end
 
-  def given_theres_a_repo
+  def given_theres_a_repo(archived: false)
     stub_request(:get, "https://api.github.com/orgs/alphagov/repos?per_page=100").
-      to_return(headers: { content_type: 'application/json' }, body: [ { full_name: 'alphagov/publishing-api', topics: ["govuk"] }, { full_name: 'alphagov/ignored-for-test', topics: ["govuk"] } ].to_json)
+      to_return(headers: { content_type: 'application/json' }, body: [ { full_name: 'alphagov/publishing-api', archived: archived, topics: ["govuk"] }, { full_name: 'alphagov/ignored-for-test', topics: ["govuk"] } ].to_json)
 
     stub_request(:get, "https://api.github.com/repos/alphagov/publishing-api/hooks?per_page=100").
       to_return(body: [].to_json, headers: { content_type: 'application/json' })
 
-    @repo_update = stub_request(:patch, "https://api.github.com/repos/alphagov/publishing-api").to_return(body: {}.to_json)
-    @branch_protection_update = stub_request(:put, "https://api.github.com/repos/alphagov/publishing-api/branches/master/protection").to_return(body: {}.to_json)
-    @hook_creation = stub_request(:post, "https://api.github.com/repos/alphagov/publishing-api/hooks").to_return(body: {}.to_json)
+    @repo_update = stub_request(:patch, "https://api.github.com/repos/alphagov/publishing-api").to_return(body: {}.to_json, status: archived ? 403 : 200)
+    @branch_protection_update = stub_request(:put, "https://api.github.com/repos/alphagov/publishing-api/branches/master/protection").to_return(body: {}.to_json, status: archived ? 403 : 200)
+    @hook_creation = stub_request(:post, "https://api.github.com/repos/alphagov/publishing-api/hooks").to_return(body: {}.to_json, status: archived ? 403 : 200)
   end
 
   def and_the_repo_has_a_jenkinsfile
@@ -61,6 +69,11 @@ RSpec.describe ConfigureRepos do
 
   def when_the_script_runs
     ConfigureRepos.new.configure!
+  end
+
+  def the_repo_is_not_updated
+    expect(@repo_update).not_to have_been_requested
+    expect(@branch_protection_update).not_to have_been_requested
   end
 
   def the_repo_is_updated_with_correct_settings


### PR DESCRIPTION
They are read-only so we can't changed them, and it's [causing the Rake task to currently fail](https://deploy.integration.publishing.service.gov.uk/job/configure-github-repos/87/console).
