### PR TITLE
Force a new review if a PR is changed after a review

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -35,7 +35,7 @@ private
         enforce_admins: true,
         required_status_checks: required_status_checks,
         required_pull_request_reviews: {
-          dismiss_stale_reviews: false,
+          dismiss_stale_reviews: true,
         }
       }
     )


### PR DESCRIPTION
This commit turns on the GitHub option that will automatically dismiss a review if the PR is changed after the review has been submitted. This forces a new review before the PR can be merged.

We're testing this setting for a week and will determine the impact before deciding whether to keep it or revert it.