### PR TITLE
Revert "Force a new review if a PR is changed after a review"

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -35,7 +35,7 @@ private
         enforce_admins: true,
         required_status_checks: required_status_checks,
         required_pull_request_reviews: {
-          dismiss_stale_reviews: true,
+          dismiss_stale_reviews: false,
         }
       }
     )


### PR DESCRIPTION
Reverts alphagov/govuk-saas-config#21

We tested this for a week, but following feedback, we've decided to roll it back as it interferes too much with the usual workflow.

The documentation on our policy with PRs will be updated to make it clearer that most rebasing and forced-push changes should result in a new review.