### PR TITLE
Allow squash merging on smart answers

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -1,9 +1,10 @@
 class ConfigureRepo
   attr_reader :repo, :client
 
-  def initialize(repo, client)
+  def initialize(repo, client, overrides = nil)
     @repo = repo
     @client = client
+    @overrides = overrides || {}
   end
 
   def configure!
@@ -18,11 +19,13 @@ class ConfigureRepo
 
 private
 
+  attr_reader :overrides
+
   def update_repo_settings
     client.edit_repository(
       repo,
       allow_merge_commit: true,
-      allow_squash_merge: false,
+      allow_squash_merge: overrides.fetch("allow_squash_merge", false),
       allow_rebase_merge: false,
     )
   end

--- a/github/lib/configure_repos.rb
+++ b/github/lib/configure_repos.rb
@@ -6,7 +6,7 @@ require_relative "./configure_repo"
 class ConfigureRepos
   def configure!
     repos.each do |repo|
-      ConfigureRepo.new(repo, client).configure!
+      ConfigureRepo.new(repo, client, repo_overrides[repo]).configure!
     end
   end
 
@@ -28,6 +28,10 @@ private
 
   def ignored_repos
     @ignored_repos ||= YAML.load_file("#{__dir__}/../ignored_repos.yml")
+  end
+
+  def repo_overrides
+    @repo_overrides ||= YAML.load_file("#{__dir__}/../repo_overrides.yml")
   end
 
   def client

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -1,0 +1,2 @@
+alphagov/smartanswers:
+  allow_squash_merge: true


### PR DESCRIPTION
It can sometimes be useful to squash all commits before merging a branch. Currently this is disallowed on all our repos.

A good example of where this is useful is when dealing with content requests. Often they will be using the GitHub website interface meaning that PRs can end up with many commits, each changing a small part of the content and even reverting older changes during the content 2i process. Ultimately, the content change is more useful as a single commit so often developers will squash all their commits before merging. This takes up time when we could use the button in GitHub.

I've implemented this as an overrides option for smartanswers, and any
other repos in the future which might want this feature.