### PR TITLE
Disable end-to-end tests as a required status check

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -94,7 +94,7 @@ private
         strict: false, # "Require branches to be up to date before merging"
         contexts: [
           "continuous-integration/jenkins/branch",
-          jenkinsfile_runs_e2e_tests? ? "continuous-integration/jenkins/publishing-e2e-tests" : nil,
+          #jenkinsfile_runs_e2e_tests? ? "continuous-integration/jenkins/publishing-e2e-tests" : nil, # Temporarily disable e2e tests
         ].compact
       }
     end

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -27,15 +27,15 @@ RSpec.describe ConfigureRepos do
     the_repo_is_not_updated
   end
 
-  it "Updates a repo with e2e tests" do
-    given_theres_a_repo
-    and_the_repo_has_a_jenkinsfile(with_e2e_tests: true)
-    when_the_script_runs
-    the_repo_is_updated_with_correct_settings
-    the_repo_has_branch_protection_activated
-    the_repo_has_ci_enabled(with_e2e_tests: true)
-    the_repo_has_webhooks_configured
-  end
+  #it "Updates a repo with e2e tests" do
+  #  given_theres_a_repo
+  #  and_the_repo_has_a_jenkinsfile(with_e2e_tests: true)
+  #  when_the_script_runs
+  #  the_repo_is_updated_with_correct_settings
+  #  the_repo_has_branch_protection_activated
+  #  the_repo_has_ci_enabled(with_e2e_tests: true)
+  #  the_repo_has_webhooks_configured
+  #end
 
   it "Doesn't set up CI if there is no Jenkinsfile" do
     given_theres_a_repo


### PR DESCRIPTION
Temporarily removing the dependence on end-to-end tests passing for all Github repos until the tests are fixed.

I've only commented out the relevant lines, rather than removing them to ensure we don't accidentally forget to put the tests back.