### PR TITLE
Re-enable e2e tests as a required status check

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -94,7 +94,7 @@ private
         strict: false, # "Require branches to be up to date before merging"
         contexts: [
           "continuous-integration/jenkins/branch",
-          #jenkinsfile_runs_e2e_tests? ? "continuous-integration/jenkins/publishing-e2e-tests" : nil, # Temporarily disable e2e tests
+          jenkinsfile_runs_e2e_tests? ? "continuous-integration/jenkins/publishing-e2e-tests" : nil,
         ].compact
       }
     end

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -27,15 +27,15 @@ RSpec.describe ConfigureRepos do
     the_repo_is_not_updated
   end
 
-  #it "Updates a repo with e2e tests" do
-  #  given_theres_a_repo
-  #  and_the_repo_has_a_jenkinsfile(with_e2e_tests: true)
-  #  when_the_script_runs
-  #  the_repo_is_updated_with_correct_settings
-  #  the_repo_has_branch_protection_activated
-  #  the_repo_has_ci_enabled(with_e2e_tests: true)
-  #  the_repo_has_webhooks_configured
-  #end
+  it "Updates a repo with e2e tests" do
+    given_theres_a_repo
+    and_the_repo_has_a_jenkinsfile(with_e2e_tests: true)
+    when_the_script_runs
+    the_repo_is_updated_with_correct_settings
+    the_repo_has_branch_protection_activated
+    the_repo_has_ci_enabled(with_e2e_tests: true)
+    the_repo_has_webhooks_configured
+  end
 
   it "Doesn't set up CI if there is no Jenkinsfile" do
     given_theres_a_repo


### PR DESCRIPTION
Publishing end to end tests are once again healthy following
https://github.com/alphagov/publishing-e2e-tests/commit/bd3a729c6706f8f33f1ffb1844a498ac3ec0c0b4
and as such, we should re-enable them as a required status check on our
repositories.

This reverts
https://github.com/alphagov/govuk-saas-config/commit/5af2df530eb806db88f26b8327369019f7d80445
which was a temporary disabling of the check which the end to end tests
were broken.