### PR TITLE
Pass option to skip deploying to integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,7 @@
 library("govuk")
 
 node {
-  govuk.buildProject()
+  govuk.buildProject(
+    skipDeployToIntegration: true
+  )
 }


### PR DESCRIPTION
We don't need to trigger a deploy to integration when merging to master
since govuk-saas-config is not a deployable application.

Depends on https://github.com/alphagov/govuk-jenkinslib/pull/54