### PR TITLE
Split out query params for finder-frontend

### DIFF
--- a/logit/aws_logstash.conf
+++ b/logit/aws_logstash.conf
@@ -48,4 +48,12 @@ else if ([application] == "syslog") {
          match => ["timestamp", "ISO8601"]
       }
    }
+
+   if ([application] == 'finder-frontend') {
+     # https://www.elastic.co/guide/en/logstash/current/plugins-filters-kv.html#plugins-filters-kv-field_split
+     kv {
+        source => "request"
+        field_split => "&? "
+     }
+   }
 }


### PR DESCRIPTION
On finder-frontend we'll be able to filter on query
parameters in Kibana which will be quite nice.

So this
/get-ready-brexit-check/results?c%5B%5D=food-drink-tobacco&c%5B%5D=owns-operates-business-organisation

will also generate this in Kibana:
c%5B%5D = food-drink-tobacco, owns-operates-business-organisation

It's also handy for search:
This: /search/all?keywords=passport&order=relevance&page=2
Yields these fields:
keywords = passport
order = relevance
page = 2

These can be filtered on in Kibana, which will help
us understand how people use search.

Note: This PR doesn't actually change anything. We have
to manually go in and change this in Logit.
See https://docs.publishing.service.gov.uk/manual/logit.html#updating-logstash-configuration

I've made this change in Logit so you can try it out in
Integration AWS.

https://trello.com/c/81JD4Cjs/982