### PR TITLE
Add prefix to finder-frontend query param keys

### DIFF
--- a/logit/aws_logstash.conf
+++ b/logit/aws_logstash.conf
@@ -54,6 +54,7 @@ else if ([application] == "syslog") {
      kv {
         source => "request"
         field_split => "&? "
+        prefix => "query."
      }
    }
 }


### PR DESCRIPTION
This change won't do anything - it's allllll manual in the logit dashboard.

It's on integration AWS if you wan't to try it.

Now query params will be prefixed with `query`, e.g.:

<img width="545" alt="Screen Shot 2019-09-06 at 15 43 17" src="https://user-images.githubusercontent.com/8124374/64436905-2c2c2e00-d0bd-11e9-8954-885dc6826dd5.png">
