### PR TITLE
Update reference to rummager for govuk-content-schemas

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -25,7 +25,7 @@ alphagov/govuk-content-schemas:
       - continuous-integration/jenkins/manuals-publisher
       - continuous-integration/jenkins/publisher
       - continuous-integration/jenkins/publishing-api
-      - continuous-integration/jenkins/rummager
+      - continuous-integration/jenkins/search-api
       - continuous-integration/jenkins/search-admin
       - continuous-integration/jenkins/service-manual-frontend
       - continuous-integration/jenkins/service-manual-publisher


### PR DESCRIPTION
The rummager repository was renamed a long while ago to search-api, so
update the check here.

This relates to this change in the govuk-content-schemas Jenkinsfile:
https://github.com/alphagov/govuk-content-schemas/pull/925