### PR TITLE
Automatically delete branches when PRs are merged

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -27,6 +27,7 @@ private
       allow_merge_commit: true,
       allow_squash_merge: overrides.fetch("allow_squash_merge", false),
       allow_rebase_merge: false,
+      delete_branch_on_merge: true,
     )
   end
 

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe ConfigureRepos do
           allow_merge_commit: true,
           allow_squash_merge: allow_squash_merge,
           allow_rebase_merge: false,
+          delete_branch_on_merge: true,
           name: full_name.split('/').last,
         }.to_json
       )


### PR DESCRIPTION
- This is an option that GitHub added to their web UI last year, and I
  started going through repos and ticking the option manually because it
  wasn't in the API.
- Now it's in the API (https://developer.github.com/v3/repos/#edit), so
  let's automatically configure all the repos to delete HEAD branches
  when PRs are merged. This doesn't delete the branches of PRs that are
  _closed_.
- This saves developers time and cuts down on the amount of stale, merged
  branches left on repos for years going forward.