### PR TITLE
Don't require the e2e tests checks to pass before being able to merge

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -95,7 +95,6 @@ private
         strict: false, # "Require branches to be up to date before merging"
         contexts: [
           "continuous-integration/jenkins/branch",
-          jenkinsfile_runs_e2e_tests? ? "continuous-integration/jenkins/publishing-e2e-tests" : nil,
           *overrides
              .fetch("required_status_checks", {})
              .fetch("additional_contexts", [])


### PR DESCRIPTION
- We're seeing a lot of intermittent Docker-related e2e tests build
  failures of the form:

```
12:05:37  ERROR: for mongo  unexpected EOF
12:05:37  unexpected EOF
12:05:37  make: *** [pull] Error 1
```

- Developers have reported a loss of productivity for having to wait for
  up to two hours and constantly re-run the e2e tests to eventually
  chance upon a working response from DockerHub.
- This is due to us using a very old version of the MongoDB Docker image
  which uses v1 of the Dockerfile API, and DockerHub are deliberately
  inserting errors when people use it to encourage them to upgrade.
- Obviously, this loss of productivity is not sustainable in the
  long-term. Hence this proposal: to make the e2e tests status check
  being green an optional thing on all PRs, so that devs can use their
  judgement as to whether to keep rerunning to try to get lucky with
  DockerHub, or - if their change doesn't affect the app in production -
  ie development gem config, or a tiny one word fix on a deadline -
  be able to skip it.

I welcome comments!