### PR TITLE
Allow "squash and merge" on alphagov/govuk-coronavirus-content PRs

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -1,6 +1,9 @@
 alphagov/smartanswers:
   allow_squash_merge: true
 
+alphagov/govuk-coronavirus-content:
+  allow_squash_merge: true
+
 alphagov/govuk-content-schemas:
   required_status_checks:
     additional_contexts:


### PR DESCRIPTION
- This repo is used by developers to turn on/off the livestream and
  update coronavirus landing and business pages.
- It's also used by content designers who change content via the GitHub
  UI. The repo has CI checks that check if the YAML is valid - say, if
  someone's put a colon in a sentence but not enclosed the whole
  sentence in quotes, that wouldn't pass CI. For cases like this,
  content designers would push a new commit with a fix.
- This could make the commit history messy, so following the lead of
  alphagov/smart-answers, this makes the
  alphagov/govuk-coronavirus-content repo allow squash merging for
  cleaner history.
- Obviously, we still prefer liberal `git commit --amend`s, `git
  rebase`s and force-pushes, but for content designers, squash-merging
  is the easiest approach without involving devs.