### PR TITLE
Remove calendars from the govuk-content-schemas status checks

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -8,7 +8,6 @@ alphagov/govuk-content-schemas:
   required_status_checks:
     additional_contexts:
       - continuous-integration/jenkins/calculators
-      - continuous-integration/jenkins/calendars
       - continuous-integration/jenkins/collections
       - continuous-integration/jenkins/collections-publisher
       - continuous-integration/jenkins/contacts


### PR DESCRIPTION
- The calendars repo is [being retired](https://github.com/alphagov/calendars/pull/861/files) as all of its functionality has moved to the frontend repo.
