### PR TITLE
ci: Use GitHub Actions instead of Jenkins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+      - uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: bundle-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: bundle
+
+      - run: bundle install --jobs 4 --retry 3 --deployment
+      - run: bundle exec rake

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,0 @@
-#!/usr/bin/env groovy
-
-library("govuk")
-
-node {
-  govuk.buildProject(
-    skipDeployToIntegration: true
-  )
-}


### PR DESCRIPTION
- Part of the implementation of [RFC 123](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-123-github-actions-ci.md).
- I've added gem caching to this as that's what we're leaning towards
  everywhere for consistency, at the time of writing.

---

Arguably we should add RuboCop to this, as it's Ruby code. But then we'd have more Dependabot PRs to merge, and it's such a small app that it doesn't feel worth it.

---

https://trello.com/c/PzpcnUdS/144-migrate-all-skipdeploytointegration-repos-ci-to-github-actions