### PR TITLE
If present, set GitHub Actions CI status checks to required on a repo

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -90,28 +90,19 @@ private
   end
 
   def required_status_checks
-    if jenkinsfile_exists?
-      {
-        strict: overrides.fetch("up_to_date_branches", false),
-        contexts: [
-          "continuous-integration/jenkins/branch",
-          jenkinsfile_runs_e2e_tests? ? "continuous-integration/jenkins/publishing-e2e-tests" : nil,
-          *overrides
-             .fetch("required_status_checks", {})
-             .fetch("additional_contexts", [])
-        ].compact
-      }
-    elsif github_actions_exists?
-      {
-        strict: overrides.fetch("up_to_date_branches", false),
-        contexts: [
-          "test",
-          *overrides
-             .fetch("required_status_checks", {})
-             .fetch("additional_contexts", [])
-        ].compact
-      }
-    end
+    return nil unless jenkinsfile_exists? || github_actions_exists?
+
+    {
+      strict: overrides.fetch("up_to_date_branches", false),
+      contexts: [
+        jenkinsfile_exists? ? "continuous-integration/jenkins/branch" : nil,
+        jenkinsfile_runs_e2e_tests? ? "continuous-integration/jenkins/publishing-e2e-tests" : nil,
+        github_actions_exists? ? "test" : nil,
+        *overrides
+          .fetch("required_status_checks", {})
+          .fetch("additional_contexts", [])
+      ].compact
+    }
   end
 
   def jenkinsfile

--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -101,6 +101,16 @@ private
              .fetch("additional_contexts", [])
         ].compact
       }
+    elsif github_actions_exists?
+      {
+        strict: false, # "Require branches to be up to date before merging"
+        contexts: [
+          "test",
+          *overrides
+             .fetch("required_status_checks", {})
+             .fetch("additional_contexts", [])
+        ].compact
+      }
     end
   end
 
@@ -126,5 +136,17 @@ private
     return false unless jenkinsfile_exists?
 
     /publishingE2ETests\:\s*true/.match(jenkinsfile_content)
+  end
+
+  def github_actions
+    @github_actions ||= begin
+      client.contents(repo, path: ".github/workflows/ci.yml")
+    rescue Octokit::NotFound
+      nil
+    end
+  end
+
+  def github_actions_exists?
+    !github_actions.nil?
   end
 end

--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -92,7 +92,7 @@ private
   def required_status_checks
     if jenkinsfile_exists?
       {
-        strict: false, # "Require branches to be up to date before merging"
+        strict: overrides.fetch("up_to_date_branches", false),
         contexts: [
           "continuous-integration/jenkins/branch",
           jenkinsfile_runs_e2e_tests? ? "continuous-integration/jenkins/publishing-e2e-tests" : nil,
@@ -103,7 +103,7 @@ private
       }
     elsif github_actions_exists?
       {
-        strict: false, # "Require branches to be up to date before merging"
+        strict: overrides.fetch("up_to_date_branches", false),
         contexts: [
           "test",
           *overrides

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -4,6 +4,15 @@ alphagov/smartanswers:
 alphagov/govuk-coronavirus-content:
   allow_squash_merge: true
 
+alphagov/govuk-coronavirus-vulnerable-people-form:
+  up_to_date_branches: true
+
+alphagov/govuk-coronavirus-business-volunteer-form:
+  up_to_date_branches: true
+
+alphagov/govuk-coronavirus-find-support:
+  up_to_date_branches: true
+
 alphagov/govuk-content-schemas:
   required_status_checks:
     additional_contexts:

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -51,11 +51,21 @@ RSpec.describe ConfigureRepos do
       the_repo_has_webhooks_configured(number_of_webhooks: 1)
     end
 
-    it "Updates an overridden repo" do
+    it "Updates a squash merge overridden repo" do
       given_theres_a_repo(full_name: "alphagov/govuk-coronavirus-content", allow_squash_merge: true)
       and_the_repo_does_not_have_a_jenkinsfile(full_name: "alphagov/govuk-coronavirus-content")
       and_the_repo_uses_github_actions(full_name: "alphagov/govuk-coronavirus-content")
       when_the_script_runs
+      the_repo_is_updated_with_correct_settings
+    end
+
+    it "Updates a strict status checks overriden repo" do
+      given_theres_a_repo(full_name: "alphagov/govuk-coronavirus-vulnerable-people-form")
+      and_the_repo_does_not_have_a_jenkinsfile(full_name: "alphagov/govuk-coronavirus-vulnerable-people-form")
+      and_the_repo_uses_github_actions(full_name: "alphagov/govuk-coronavirus-vulnerable-people-form")
+      when_the_script_runs
+      the_repo_has_ci_enabled(full_name: "alphagov/govuk-coronavirus-vulnerable-people-form", provider: "github_actions", up_to_date_branches: true)
+      the_repo_has_branch_protection_activated
       the_repo_is_updated_with_correct_settings
     end
   end
@@ -162,10 +172,10 @@ RSpec.describe ConfigureRepos do
     expect(@branch_protection_update).to have_been_requested
   end
 
-  def the_repo_has_ci_enabled(full_name: "alphagov/publishing-api", provider: "jenkins", with_e2e_tests: false)
+  def the_repo_has_ci_enabled(full_name: "alphagov/publishing-api", provider: "jenkins", with_e2e_tests: false, up_to_date_branches: false)
     payload = {
       required_status_checks: {
-        strict: false,
+        strict: up_to_date_branches,
         contexts: [
           provider == "jenkins" ? "continuous-integration/jenkins/branch" : nil,
           provider == "github_actions" ? "test" : nil,


### PR DESCRIPTION
- Now we're using more GitHub Actions as per RFC 123, we need to automatically configure required status checks if a repo uses them. Otherwise, we have to do it manually and that wastes time and could lead to inconsistencies between the repos.
- Allow overriding `strict: true`, that is "branches must be up-to-date with `master` before merging". Configure this for the coronavirus forms repos due to some issues we had with RuboCop being broken on master. I figured this might be good to have in Jenkins too for some repos maybe, so I've added it there too.

I could probably do some refactoring to make this have less duplication, but that's for if I get really bored later today...

Fixes #42.
https://trello.com/c/xrJZFaaC/443-%F0%9F%8D%90set-github-actions-ci-checks-to-required-if-present-in-repos


