### PR TITLE
Stop overriding `up_to_date_branches` setting for COVID forms repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on: [push, pull_request]
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -4,15 +4,6 @@ alphagov/smartanswers:
 alphagov/govuk-coronavirus-content:
   allow_squash_merge: true
 
-alphagov/govuk-coronavirus-vulnerable-people-form:
-  up_to_date_branches: true
-
-alphagov/govuk-coronavirus-business-volunteer-form:
-  up_to_date_branches: true
-
-alphagov/govuk-coronavirus-find-support:
-  up_to_date_branches: true
-
 alphagov/govuk-content-schemas:
   required_status_checks:
     additional_contexts:

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -4,6 +4,9 @@ alphagov/smartanswers:
 alphagov/govuk-coronavirus-content:
   allow_squash_merge: true
 
+alphagov/repo-for-govuk-saas-config-automated-tests:
+  up_to_date_branches: true
+
 alphagov/govuk-content-schemas:
   required_status_checks:
     additional_contexts:

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -63,11 +63,11 @@ RSpec.describe ConfigureRepos do
     end
 
     it "Updates a strict status checks overriden repo" do
-      given_theres_a_repo(full_name: "alphagov/govuk-coronavirus-vulnerable-people-form")
-      and_the_repo_does_not_have_a_jenkinsfile(full_name: "alphagov/govuk-coronavirus-vulnerable-people-form")
-      and_the_repo_uses_github_actions(full_name: "alphagov/govuk-coronavirus-vulnerable-people-form")
+      given_theres_a_repo(full_name: "alphagov/repo-for-govuk-saas-config-automated-tests")
+      and_the_repo_does_not_have_a_jenkinsfile(full_name: "alphagov/repo-for-govuk-saas-config-automated-tests")
+      and_the_repo_uses_github_actions(full_name: "alphagov/repo-for-govuk-saas-config-automated-tests")
       when_the_script_runs
-      the_repo_has_ci_enabled(full_name: "alphagov/govuk-coronavirus-vulnerable-people-form", providers: ["github_actions"], up_to_date_branches: true)
+      the_repo_has_ci_enabled(full_name: "alphagov/repo-for-govuk-saas-config-automated-tests", providers: ["github_actions"], up_to_date_branches: true)
       the_repo_has_branch_protection_activated
       the_repo_is_updated_with_correct_settings
     end


### PR DESCRIPTION
- This was a noble goal, but with the rate of change and the number of
  people, and the proliferation of merge commits from the GitHub UI
  button, this didn't work for us.