### PR TITLE
Restrict PR merge for Smart Answers

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -32,17 +32,21 @@ private
   end
 
   def protect_branch
-    client.protect_branch(
-      repo,
-      "master",
-      {
-        enforce_admins: true,
-        required_status_checks: required_status_checks,
-        required_pull_request_reviews: {
-          dismiss_stale_reviews: false,
-        }
+    config = {
+      enforce_admins: true,
+      required_status_checks: required_status_checks,
+      required_pull_request_reviews: {
+        dismiss_stale_reviews: false,
       }
-    )
+    }
+
+    if overrides["need_production_access_to_merge"]
+      config.merge!(
+        restrictions: { users: [], teams: %w[alphagov/gov-uk-production] }
+      )
+    end
+
+    client.protect_branch(repo, "master", config)
   end
 
   def update_webhooks

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -1,5 +1,6 @@
 alphagov/smartanswers:
   allow_squash_merge: true
+  need_production_access_to_merge: true
 
 alphagov/govuk-coronavirus-content:
   allow_squash_merge: true


### PR DESCRIPTION
https://trello.com/c/YsFgKiR0/166-restrict-permission-to-merge-pull-requests-to-master-to-the-govuk-production-github-group

Previously we agreed that on a beta Continuous Deployment involving
this repo, with the caveat that any changes should only be mergeable
by people who would otherwise be manually deploying them. This adds
a merge restriction to the existing 'master' branch protections for
Smart Answers, with scope to add more repos in future.