### PR TITLE
Restrict merge access to most GOV.UK repos

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -40,7 +40,7 @@ private
       }
     }
 
-    if overrides["need_production_access_to_merge"]
+    unless overrides["do_not_need_production_access_to_merge"]
       config.merge!(
         restrictions: { users: [], teams: %w[gov-uk-production] }
       )

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -1,9 +1,8 @@
 alphagov/smart-answers:
   allow_squash_merge: true
-  need_production_access_to_merge: true
 
-alphagov/publishing-api:
-  need_production_access_to_merge: true
+alphagov/govuk-puppet:
+  do_not_need_production_access_to_merge: true
 
 alphagov/govuk-coronavirus-content:
   allow_squash_merge: true


### PR DESCRIPTION
https://trello.com/c/TUB9OGWD/152-prepare-and-run-a-beta-trial-of-continuous-deployment

**Deadline for discussion: 2020-06-30**

    This restriction is necessary for apps with Continuous Deployment
    enabled i.e. where "merge" is the same as "deploy". Currently, the
    set of developers without production access may include people without
    security clearance, for whom we have to assume a worst case scenario.
    
    As part of moving to Continuous Deployment, we will incrementally
    override each repo to add this restriction. Rather than adding lots
    of overrides, we should try to make a clear policy decision about
    whether non-production developers should be able to merge PRs.
    
    Exceptions to this:
    
    - govuk-puppet - some changes only apply to Integration, such as
    initial PRs for someone joining GOV.UK [1]
    
    Reasons for this change:
    
    - We avoid building up a set of overrides for Continuous Deployment.
    
    - We more clearly align deploying and change with merging it (since
    the person merging it is always able to).
    
    - People deploying changes can have more visibility of them, having
    merged the changes they are deploying themselves.
    
    - A higher barrier to merge for new joiners should promote the good
    habit of doing branch deploys for any manual testing.
    
    Reasons against this change:
    
    - Some loss of satisfaction of merging your own PR, even though you
    couldn't actually deploy it to Production.
    
    - Some additional workload on developers with production access, who
    will now be asked to merge PRs, as well as deploy them.
    
    [1]: https://docs.publishing.service.gov.uk/manual/get-started.html#6-get-ssh-access-to-integration

Follow-up tasks:

- [ ] Update [our docs](https://docs.publishing.service.gov.uk/manual/merge-pr.html) to cover the restriction
- [ ] Send an email round to make everyone aware