### PR TITLE
Ensure Travis checks pass for Data.gov.uk

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -1,3 +1,13 @@
+alphagov/datagovuk_find:
+  required_status_checks:
+    additional_contexts:
+      - continuous-integration/travis-ci
+
+alphagov/datagovuk_publish:
+  required_status_checks:
+    additional_contexts:
+      - continuous-integration/travis-ci
+
 alphagov/smart-answers:
   allow_squash_merge: true
   need_production_access_to_merge: true


### PR DESCRIPTION
Data.gov.uk uses Travis as its CI environment. This means that when this tool runs, the required status checks get switched off because this tool only knows about Jenkins.

By adding these overrides, it should ensure that the status checks are required for both Data.gov.uk Find and Publish.