### PR TITLE
Use the default branch name configured on the repo

### DIFF
--- a/github/lib/configure_repos.rb
+++ b/github/lib/configure_repos.rb
@@ -6,7 +6,7 @@ require_relative "./configure_repo"
 class ConfigureRepos
   def configure!
     repos.each do |repo|
-      ConfigureRepo.new(repo, client, repo_overrides[repo]).configure!
+      ConfigureRepo.new(repo, client, repo_overrides[repo[:full_name]]).configure!
     end
   end
 
@@ -22,8 +22,7 @@ private
       .select { |repo| repo.topics.to_a.include?("govuk") }
       .reject { |repo| ignored_repos.include?(repo.full_name) }
       .reject { |repo| repo.archived }
-      .map(&:full_name)
-      .sort
+      .sort_by { |repo| repo[:full_name] }
   end
 
   def ignored_repos


### PR DESCRIPTION
We are currently hardcoding the default branch name `master` as a protected branch.

This is problematic in two respects:
 - The name of this branch name is racially insensitive (GDS are migrating towards `main`, in place of `master`
 - It stops us having a default branch with a different name

Instead we will now protect the branch that is configured by default on the repo in GitHub.