### PR TITLE
Restrict merge access for 5 more apps

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -10,9 +10,38 @@ alphagov/datagovuk_publish:
 
 alphagov/smart-answers:
   allow_squash_merge: true
+  # required for continuous deployment
+  # https://docs.google.com/document/d/18y2flzqbhytlithxuiyxkzndw4tzmpiqzak-3rkgpbg/edit
   need_production_access_to_merge: true
 
 alphagov/publishing-api:
+  # required for continuous deployment
+  # https://docs.google.com/document/d/18y2flzqbhytlithxuiyxkzndw4tzmpiqzak-3rkgpbg/edit
+  need_production_access_to_merge: true
+
+alphagov/travel-advice-publisher:
+  # required for continuous deployment
+  # https://docs.google.com/document/d/18y2flzqbhytlithxuiyxkzndw4tzmpiqzak-3rkgpbg/edit
+  need_production_access_to_merge: true
+
+alphagov/publisher:
+  # required for continuous deployment
+  # https://docs.google.com/document/d/18y2flzqbhytlithxuiyxkzndw4tzmpiqzak-3rkgpbg/edit
+  need_production_access_to_merge: true
+
+alphagov/finder-frontend:
+  # required for continuous deployment
+  # https://docs.google.com/document/d/18y2flzqbhytlithxuiyxkzndw4tzmpiqzak-3rkgpbg/edit
+  need_production_access_to_merge: true
+
+alphagov/collections:
+  # required for continuous deployment
+  # https://docs.google.com/document/d/18y2flzqbhytlithxuiyxkzndw4tzmpiqzak-3rkgpbg/edit
+  need_production_access_to_merge: true
+
+alphagov/government-frontend:
+  # required for continuous deployment
+  # https://docs.google.com/document/d/18y2flzqbhytlithxuiyxkzndw4tzmpiqzak-3rkgpbg/edit
   need_production_access_to_merge: true
 
 alphagov/govuk-coronavirus-content:


### PR DESCRIPTION
https://trello.com/c/vFPSSGb7/175-activate-continuous-deployment-for-5-more-apps

This should be merged in advance of enabling Continous Deployment
for these repos, so that we have an opportunity to raise any issues
that result from these restrictions in our teams.