### PR TITLE
Change GitHub branch protection enforce admins to false

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -33,7 +33,7 @@ private
 
   def protect_branch
     config = {
-      enforce_admins: true,
+      enforce_admins: false,    # Temporary
       required_status_checks: required_status_checks,
       required_pull_request_reviews: {
         dismiss_stale_reviews: false,

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe ConfigureRepos do
       .to_return(body: {}.to_json, status: archived ? 403 : 200)
 
     @branch_protection_update = stub_request(:put, "https://api.github.com/repos/#{full_name}/branches/#{default_branch}/protection")
-      .with(body: { enforce_admins: true,
+      .with(body: { enforce_admins: false,
               required_status_checks: hash_including({}),
               required_pull_request_reviews: {
                 dismiss_stale_reviews: false,


### PR DESCRIPTION
There's currently issues with the Publishing E2E Tests Jenkins job
updating the GitHub commit status, which blocks merging Pull Requests
because this is a required check.

To make it easier for people to check the Publishing E2E Tests passed,
and then merge regardless of the pending check, change enforce admins
to false. This should be reverted once the Jenkins -> GitHub status
reporting is fixed.