### PR TITLE
Update Github branch protection to decode base64 string

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -1,3 +1,6 @@
+require 'base64'
+require 'yaml'
+
 class ConfigureRepo
   attr_reader :repo, :client
 
@@ -136,7 +139,9 @@ private
 
   def github_actions
     @github_actions ||= begin
-      client.contents(repo[:full_name], path: ".github/workflows/ci.yml")
+      encoded_content = client.contents(repo[:full_name], path: ".github/workflows/ci.yml").content
+      decoded_content = Base64.decode64(encoded_content)
+      YAML.load(decoded_content)
     rescue Octokit::NotFound
       nil
     end
@@ -147,10 +152,10 @@ private
   end
 
   def github_actions_test_exists?
-    !github_actions.nil? && github_actions.key?(:jobs) && github_actions[:jobs].key?(:test)
+    !github_actions.nil? && github_actions.key?("jobs") && github_actions["jobs"].key?("test")
   end
 
   def github_actions_pre_commit_exists?
-    !github_actions.nil? && github_actions.key?(:jobs) && github_actions[:jobs].key?(:'pre-commit')
+    !github_actions.nil? && github_actions.key?("jobs") && github_actions["jobs"].key?("pre-commit")
   end
 end

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../spec_helper'
 require_relative '../../lib/configure_repos'
 
+require 'base64'
+require 'yaml'
+
 RSpec.describe ConfigureRepos do
   context "when a repo uses Jenkins for CI" do
     it "Updates a repo" do
@@ -173,11 +176,15 @@ RSpec.describe ConfigureRepos do
   end
 
   def and_the_repo_uses_github_actions_for_test(full_name: "alphagov/govuk-coronavirus-content")
-    payload = {
-      on: %w[push pull_request],
-      jobs: {
-        test: {},
+    content = {
+      "on" => %w[push pull_request],
+      "jobs" => {
+        "test" => {},
       }
+    }
+
+    payload = {
+      content: Base64.encode64(content.to_yaml)
     }
 
     stub_request(:get, "https://api.github.com/repos/#{full_name}/contents/.github/workflows/ci.yml").
@@ -185,12 +192,16 @@ RSpec.describe ConfigureRepos do
   end
 
   def and_the_repo_uses_github_actions_for_test_and_pre_commit(full_name: "alphagov/govuk-coronavirus-content")
-    payload = {
-      on: %w[push pull_request],
-      jobs: {
-        test: {},
-        'pre-commit': {},
+    content = {
+      "on" => %w[push pull_request],
+      "jobs" => {
+        "test" => {},
+        "pre-commit" => {},
       }
+    }
+
+    payload = {
+      content: Base64.encode64(content.to_yaml)
     }
 
     stub_request(:get, "https://api.github.com/repos/#{full_name}/contents/.github/workflows/ci.yml").


### PR DESCRIPTION
In a previous commit, we read the ci.yml Github Actions file to determine which branch protections to add. However, we failed to account for Github returning the file contents as base64 enoded. Therefore adding this here.

Trello card: https://trello.com/c/OZH2YUIg