### PR TITLE
Fix typo in "Could not find repo" error message

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -17,7 +17,7 @@ class ConfigureRepo
     update_webhooks
     puts "√ #{repo[:full_name]}"
   rescue Octokit::NotFound => e
-    puts "Could not find #{repo[:full_name]}. Possibly the govuk-ci user doesn't have admin access to this repo[:full_name]."
+    puts "Could not find #{repo[:full_name]}. Possibly the govuk-ci user doesn't have admin access to this repo."
   end
 
 private


### PR DESCRIPTION
- The `repo` variable was changed to `repo[:full_name]` in 9f1fa35 and there appears to have been one too many "find and replace" operations as this un-interpolated `repo[:full_name]` doesn't make sense.

(I mostly came here to see if you'd made it off of Jenkins yet. 😉)