### PR TITLE
Restrict merge access to {info/manuals}-frontend

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -44,6 +44,16 @@ alphagov/government-frontend:
   # https://docs.google.com/document/d/18y2flzqbhytlithxuiyxkzndw4tzmpiqzak-3rkgpbg/edit
   need_production_access_to_merge: true
 
+alphagov/manuals-frontend:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
+alphagov/info-frontend:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/govuk-coronavirus-content:
   allow_squash_merge: true
 


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

This is part of the safety criteria for enabling automatic deployments.