### PR TITLE
Require production access to merge authenticating-proxy

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -8,6 +8,11 @@ alphagov/datagovuk_publish:
     additional_contexts:
       - continuous-integration/travis-ci
 
+alphagov/authenticating-proxy:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/smart-answers:
   allow_squash_merge: true
   # required for continuous deployment


### PR DESCRIPTION
This is required as the app is now deployed automatically: https://github.com/alphagov/govuk-puppet/pull/10843