### PR TITLE
Require production access to merge bouncer

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -13,6 +13,11 @@ alphagov/authenticating-proxy:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/bouncer:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/smart-answers:
   allow_squash_merge: true
   # required for continuous deployment


### PR DESCRIPTION
This is required as the app will soon be deployed automatically:
https://github.com/alphagov/govuk-puppet/pull/10858