### PR TITLE
Require production access to merge HMRC Manuals API

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -44,6 +44,11 @@ alphagov/government-frontend:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/hmrc-manuals-api:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/manuals-frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
Prerequisite for enabling continuous deployment for HMRC Manuals API