### PR TITLE
Require production access to merge short url manager

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -23,6 +23,11 @@ alphagov/content-data-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/short-url-manager:
+    # required for continuous deployment
+    # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+    need_production_access_to_merge: true
+
 alphagov/smart-answers:
   allow_squash_merge: true
   # required for continuous deployment


### PR DESCRIPTION
In line with the requirements to enable continuous deployment. We are
requiring production access to merge a pull request in short-url-manager

Co-Authored-By: Edward Kerry <edward.kerry@digital.cabinet-office.gov.uk>