### PR TITLE
Restricts merge access for Email Alert Frontend

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -23,10 +23,15 @@ alphagov/content-data-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/email-alert-frontend:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/short-url-manager:
-    # required for continuous deployment
-    # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
-    need_production_access_to_merge: true
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
 
 alphagov/smart-answers:
   allow_squash_merge: true


### PR DESCRIPTION
As we enable CD we need to restrict merge access to production users so
only authorised users can deploy to production.

Also removes some excessive whitespace.