### PR TITLE
Restrict merge access for LLM

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -33,6 +33,11 @@ alphagov/email-alert-frontend:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/local-links-manager:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/short-url-manager:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
LLM is now continuously deployed so we need to restrict merge access to
only GOV.UK production users as per the [automatic deployment requirements].

Trello:
https://trello.com/c/uAx6eKAQ/2276-activate-continuous-deployment-for-local-links-manager

[automatic deployment requirements]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#automatic-deployments