### PR TITLE
Require production access to merge Frontend

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -33,6 +33,11 @@ alphagov/email-alert-frontend:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/frontend:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/local-links-manager:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
Now that Continuous Deployment is enabled:
https://github.com/alphagov/govuk-puppet/pull/10967