### PR TITLE
Require Prod access for Service Manual Frontend

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -104,6 +104,11 @@ alphagov/content-data-admin:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/service-manual-frontend:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/service-manual-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
Prep for enabling continous deployment.

Trello:
https://trello.com/c/zu7IYR6C/2385-enable-continuous-deployment-for-service-manual-frontend