### PR TITLE
Require production access to merge Collections

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -18,6 +18,11 @@ alphagov/bouncer:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/collections:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/collections-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
This is a requirement for continuous deployment:

https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
https://trello.com/c/7IDYweEc/2399-enable-continuous-deployment-for-collections