### PR TITLE
Restrict merge access for Sidekiq Monitoring

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -119,6 +119,11 @@ alphagov/service-manual-publisher:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/sidekiq-monitoring:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/govuk-coronavirus-content:
   allow_squash_merge: true
 


### PR DESCRIPTION
Require for enabling CD.

Trello:
https://trello.com/c/C1cWKFAb/2392-5-enable-continuous-deployment-for-sidekiq-monitoring