### PR TITLE
Remove calculators from gds-api-adapters checks

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -138,7 +138,6 @@ alphagov/repo-for-govuk-saas-config-automated-tests:
 alphagov/govuk-content-schemas:
   required_status_checks:
     additional_contexts:
-      - continuous-integration/jenkins/calculators
       - continuous-integration/jenkins/collections
       - continuous-integration/jenkins/collections-publisher
       - continuous-integration/jenkins/contacts


### PR DESCRIPTION
The app has been retired now, so we no longer need this checks to pass (and in fact they don't work!).