### PR TITLE
Require production access to merge Support

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -129,6 +129,11 @@ alphagov/sidekiq-monitoring:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/support:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/govuk-coronavirus-content:
   allow_squash_merge: true
 


### PR DESCRIPTION
https://trello.com/c/YPh5Epuc/2433-5-enable-continuous-deployment-for-support-app