### PR TITLE
Require production access to merge cache-clearing-service

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -28,6 +28,11 @@ alphagov/collections:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/cache-clearing-service:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/collections-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
Done as part of enabling CD for cache-clearing-service

Trello: https://trello.com/c/29b0FSiU/2496-3-enable-continuous-deployment-for-cache-clearing-service