### PR TITLE
Require production access to merge Imminence

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -53,6 +53,11 @@ alphagov/frontend:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/imminence:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/local-links-manager:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
https://trello.com/c/WglS9ZVW/2522-3-enable-continuous-deployment-for-imminence