### PR TITLE
Restrict merge access to prod users

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -149,6 +149,11 @@ alphagov/support:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/whitehall:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/govuk-coronavirus-content:
   allow_squash_merge: true
 


### PR DESCRIPTION
When we enable CD, only Production users will be able to merge PRs.

Trello: https://trello.com/c/LCR0Am73/2541-5-enable-continuous-deployment-for-whitehall