### PR TITLE
Require production access to merge email alert service

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -48,6 +48,11 @@ alphagov/email-alert-frontend:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/email-alert-service:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
https://trello.com/c/AGNZWDFJ/2693-enable-continuous-deployment-for-email-alert-service-3