### PR TITLE
Add link to govuk-infra to GitHub section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Tool to create and manage lots of applications in Sentry
 
 Tool to make sure all GOV.UK repos have the same settings and webhooks.
 
+> **Note**: Some GitHub resources are configured by the [govuk-infrastructure project](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/README.md). We are considering migrating this configuration to
+> Terraform. That we have two ways of configuring GitHub resources is [tracked as tech debt](https://trello.com/c/mojlsebq/226-we-have-two-tools-for-managing-github-resources).
+
 ## [Logit](/logit)
 
 Configuration related to Logit, such as Logstash configuration.


### PR DESCRIPTION
We're planning to add more GitHub configuration to Terraform, and may migrate the Ruby-based config hosted here to Terraform.