### PR TITLE
Require production access to merge Feedback

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -53,6 +53,11 @@ alphagov/email-alert-service:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/feedback:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
One of the steps to enable continuous deployment is to require production access
for new PRs to be merged

https://trello.com/c/aFEtQrTu