### PR TITLE
Add new deploy Github team

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -45,7 +45,7 @@ private
 
     if overrides["need_production_access_to_merge"]
       config.merge!(
-        restrictions: { users: [], teams: %w[gov-uk-production] }
+        restrictions: { users: [], teams: %w[gov-uk-production gov-uk-production-deploy] }
       )
     end
 

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe ConfigureRepos do
                 dismiss_stale_reviews: false,
               },
               restrictions: need_production_access_to_merge ?
-               { users: [], teams: %w[gov-uk-production] } : nil,
+               { users: [], teams: %w[gov-uk-production gov-uk-production-deploy] } : nil,
             })
       .to_return(body: {}.to_json, status: archived ? 403 : 200)
 


### PR DESCRIPTION
We are adding a new level of access, which allows engineers to deploy
code but not administer related systems. This uses the new Github
team https://github.com/orgs/alphagov/teams/gov-uk-production-deploy
and allows users to merge PRs in repos that have CD enabled.

Trello card: https://trello.com/c/docwZ4Gm/2892-implement-production-deploy-access-5