### PR TITLE
Require production access to merge Specialist Publisher

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -99,6 +99,11 @@ alphagov/smart-answers:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/specialist-publisher:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/travel-advice-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
For the ticket on [enabling CD for Specialist Publisher](https://trello.com/c/NfdjEbQi/261-enable-continuous-deployment-for-specialist-publisher)

Similar to [this PR on Manuals Publisher ](https://github.com/alphagov/govuk-saas-config/pull/72)