### PR TITLE
Rename Github production team name

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -45,7 +45,7 @@ private
 
     if overrides["need_production_access_to_merge"]
       config.merge!(
-        restrictions: { users: [], teams: %w[gov-uk-production gov-uk-production-deploy] }
+        restrictions: { users: [], teams: %w[gov-uk-production-admin gov-uk-production-deploy] }
       )
     end
 

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe ConfigureRepos do
                 dismiss_stale_reviews: false,
               },
               restrictions: need_production_access_to_merge ?
-               { users: [], teams: %w[gov-uk-production gov-uk-production-deploy] } : nil,
+               { users: [], teams: %w[gov-uk-production-admin gov-uk-production-deploy] } : nil,
             })
       .to_return(body: {}.to_json, status: archived ? 403 : 200)
 


### PR DESCRIPTION
As covered in https://github.com/alphagov/govuk-rfcs/blob/main/rfc-146-production-deploy-access.md
we are renaming the production team name from "GOV.UK Production"
to "GOV.UK Production Admin".

Trello card: https://trello.com/c/docwZ4Gm/2892-implement-production-deploy-access-5