### PR TITLE
Remove `manuals-frontend` status check for Content Schemas

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -209,7 +209,6 @@ alphagov/govuk-content-schemas:
       - continuous-integration/jenkins/hmrc-manuals-api
       - continuous-integration/jenkins/info-frontend
       - continuous-integration/jenkins/licencefinder
-      - continuous-integration/jenkins/manuals-frontend
       - continuous-integration/jenkins/manuals-publisher
       - continuous-integration/jenkins/publisher
       - continuous-integration/jenkins/publishing-api


### PR DESCRIPTION
In https://github.com/alphagov/govuk-content-schemas/pull/1102, we have removed the check for `govuk-content-schemas` against `manuals-frontend`.

This removes the status check from the GitHub repo, so PRs can be merged without expecting this non-existent job to run.

The setting can also be manually edited [through the GitHub UI](https://github.com/alphagov/govuk-content-schemas/settings/branch_protection_rules/28987), although this will be overwritten next time the SaaS config job is run.