### PR TITLE
Revert "Require production access to merge publishing api"

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -114,11 +114,6 @@ alphagov/publisher:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
-alphagov/publishing-api:
-  # required for continuous deployment
-  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
-  need_production_access_to_merge: true
-
 alphagov/finder-frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
This reverts commit 0fba616cc3db749c282bbaea99a3f71420cc7b54.

Reverting while we look at pact tests before enabling CD.