### PR TITLE
Require production access to merge publishing api

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -114,6 +114,11 @@ alphagov/publisher:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/publishing-api:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/finder-frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
This PR requires production access for merging publishing api, as part of enabling continuous deployment for the app.

Requires merging first:

Publishing api PRs to remove legacy / unused endpoints (various)
[Add PR template](https://github.com/alphagov/publishing-api/pull/2098) to publishing api

[Ticket](https://trello.com/c/FNtolpuM/13-enable-continuous-deployment-for-publishing-api)