### PR TITLE
Require production access to merge asset manager

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -13,6 +13,11 @@ alphagov/account-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/asset-manager:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/authenticating-proxy:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
This PR requires production access for merging asset manager, as part of enabling continuous deployment for the app.

Requires merging first: 

* Pact tests and smokey tagging (various)
* [Add PR template](https://github.com/alphagov/asset-manager/pull/927) to asset manager 

[Ticket](https://trello.com/c/Sj4UTatV/126-enable-continuous-deployment-for-asset-manager)