### PR TITLE
Require production access to merge Email Alert API

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -53,6 +53,11 @@ alphagov/content-data-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/email-alert-api:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/email-alert-frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
https://trello.com/c/NBntcDk5/1166-enable-continuous-deployment-for-email-alert-api