### PR TITLE
Require production access to merge licence-finder.

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -149,6 +149,11 @@ alphagov/hmrc-manuals-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/licence-finder:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/manuals-frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
We may as well do this now, since it's a trivial change and without CD anyone merging LF has to have production access to deploy it anyway, so temporarily having two gates instead of one isn't really slowing anyone down.

https://trello.com/c/JS4sbFS3/1416-enable-continuous-deployment-for-license-finder