### PR TITLE
Require production access to merge content-store

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -53,6 +53,11 @@ alphagov/content-data-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/content-store:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/content-tagger:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
Required for CD

Trello: https://trello.com/c/aDiHro0u/26-enable-continuous-deployment-for-content-store