### PR TITLE
Allow 'squash merge' for tech docs repos

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -63,6 +63,12 @@ alphagov/content-tagger:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/data-community-tech-docs:
+  allow_squash_merge: true
+
+alphagov/datagovuk-tech-docs:
+  allow_squash_merge: true
+
 alphagov/email-alert-api:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
@@ -87,6 +93,15 @@ alphagov/frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+
+alphagov/govuk-content-api-docs:
+  allow_squash_merge: true
+
+alphagov/govuk-developer-docs:
+  allow_squash_merge: true
+
+alphagov/govuk-kubernetes-cluster-user-docs:
+  allow_squash_merge: true
 
 alphagov/imminence:
   # required for continuous deployment


### PR DESCRIPTION
There are two cases where enabling 'squash merge' on tech docs repos would be beneficial.

1) For PRs raised by non-developers (product managers, tech
   writers, etc). Some don't have the technical knowledge to
   perform amends and rebases confidently, and some may not even
   have the option to do that at all if they're on a machine
   without admin privileges.
2) Developers raising PRs via the GitHub user interface. We want
   to make the act of updating documentation as frictionless as
   possible, to encourage devs to keep docs up to date. The UI
   provides a convenient way of making edits without having to
   check out the repository and manually create a branch etc.
   If the developer corrects a typo in the subsequent commit,
   we don't want them to have to switch to the CLI method just to
   tidy up their PR.

We have precedents set already, in
- https://github.com/alphagov/govuk-saas-config/pull/25
- https://github.com/alphagov/govuk-saas-config/pull/43

The original commit where the default setting was to disallow squash merging doesn't go into much detail either: d2fdb2f1b4df0e6a889af12e09360ff3d2db6102

So, whilst rebasing locally is more powerful, flexible and controllable than squashing via the UI, there seems little risk in enabling it on these tech docs repos.