### PR TITLE
Require production access to merge publishing api

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -224,6 +224,11 @@ alphagov/sidekiq-monitoring:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/signon:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/support:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
Do not merge yet, depends on:

* [Adding PR template](https://github.com/alphagov/signon/pull/1960)
* which in turn depends on various PRs to increase test coverage

[Trello](https://trello.com/c/jBtHWHBh/14-enable-continuous-deployment-for-signon)