### PR TITLE
Require production access to merge PRs for Link Checker API

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -108,6 +108,11 @@ alphagov/imminence:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/link-checker-api:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/local-links-manager:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
This is a requirement for continuously deployed applications, so making that change here now that Link Checker API will shortly be enabled for CD.

[Trello card](https://trello.com/c/xyWyqqhq/15-enable-continuous-deployment-for-link-checker-api)