### PR TITLE
Remove required checks for Publishing E2E tests

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -103,7 +103,6 @@ private
       strict: overrides.fetch("up_to_date_branches", false),
       contexts: [
         jenkinsfile_exists? ? "continuous-integration/jenkins/branch" : nil,
-        jenkinsfile_runs_e2e_tests? ? "continuous-integration/jenkins/publishing-e2e-tests" : nil,
         github_actions_test_exists? ? "test" : nil,
         github_actions_pre_commit_exists? ? "pre-commit" : nil,
         *overrides
@@ -129,12 +128,6 @@ private
     return nil unless jenkinsfile_exists?
     raise "Unknown encoding" unless jenkinsfile.encoding == "base64"
     Base64.decode64(jenkinsfile.content)
-  end
-
-  def jenkinsfile_runs_e2e_tests?
-    return false unless jenkinsfile_exists?
-
-    /publishingE2ETests\:\s*true/.match(jenkinsfile_content)
   end
 
   def github_actions


### PR DESCRIPTION
We're decommissioning the [Publishing E2E tests][] now that GOV.UK apps have transitioned to a model of continuous deployment with contract tests, as outlined in [RFC-128][]. The overall progress of this work is tracked in a [Trello card on the GOV.UK Tech Debt board][tech-debt-card].

This commit removes required status checks on GitHub repositories that make use of the Publishing E2E tests. This will have the effect of stopping any future runs of Publishing E2E tests from blocking Pull Requests from being merged in on affected repositories – since we now consider these tests redundant.

[Publishing E2E tests]: https://github.com/alphagov/publishing-e2e-tests
[RFC-128]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-128-continuous-deployment.md#delete-publishing-e2e-tests
[tech-debt-card]: https://trello.com/c/Lbw4TTfD/233-publishing-e2e-tests-still-exist