### PR TITLE
Require production access to merge into Transition

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -239,6 +239,11 @@ alphagov/support:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
 
+alphagov/transition:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/whitehall:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
This is a required step before we can enable continuous deployment for the application.

[Trello card](https://trello.com/c/VgRHbI98)