### PR TITLE
Add Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ Tool to make sure all GOV.UK repos have the same settings and webhooks.
 ## [Logit](/logit)
 
 Configuration related to Logit, such as Logstash configuration.
+
+## Licence
+
+[MIT License](LICENCE)
+


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence