### PR TITLE
Making sure GOVUK tagged repos on GitHub are in sync with...

### DIFF
--- a/github/lib/configure_repos.rb
+++ b/github/lib/configure_repos.rb
@@ -36,13 +36,12 @@ class ConfigureRepos
   end
 
   def verify_repo_tags!
-    # TODO: make these work
     govuk_repo_names = JSON.load(URI.open("https://docs.publishing.service.gov.uk/repos.json")).map { |repo| repo["app_name"] }
     github_repo_names = github_repos_tagged_govuk.map { |repo| repo["name"] }
     
     untagged_govuk_repo_names = govuk_repo_names - github_repo_names
     falsely_tagged_govuk_repo_names = github_repo_names - govuk_repo_names
-    # TODO: print these out
+    
     puts "Untagged govuk repos: #{untagged_govuk_repo_names}"
     puts "Falsely tagged govuk repos: #{falsely_tagged_govuk_repo_names}"
   end

--- a/github/tasks.rake
+++ b/github/tasks.rake
@@ -15,4 +15,9 @@ namespace :github do
   task :remove_old_webhooks do
     ConfigureRepos.new.remove_old_webhooks!
   end
+
+  desc "Verify that GOVUK repos are tagged #govuk"
+  task :verify_repo_tags do
+    ConfigureRepos.new.verify_repo_tags!
+  end
 end


### PR DESCRIPTION
A script checking both sources and highlighting repositories where they are in the devdocs repos.yml list, but aren't tagged GOVUK on GitHub, and repos tagged GOVUK which are  not listed in the yml list.

Trello card: https://trello.com/c/x7rPEBID/3095-making-sure-the-repositories-tagged-as-govuk-on-github-are-in-sync-with-the-reposyml-data