### PR TITLE
Fix required status checks when `test` job has a custom name

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -103,7 +103,7 @@ private
       strict: overrides.fetch("up_to_date_branches", false),
       contexts: [
         jenkinsfile_exists? ? "continuous-integration/jenkins/branch" : nil,
-        github_actions_test_exists? ? "test" : nil,
+        github_actions_test_job_name,
         github_actions_pre_commit_exists? ? "pre-commit" : nil,
         *overrides
           .fetch("required_status_checks", {})
@@ -141,11 +141,14 @@ private
   end
 
   def github_actions_exists?
-    github_actions_test_exists? || github_actions_pre_commit_exists?
+    !github_actions_test_job_name.nil? || github_actions_pre_commit_exists?
   end
 
-  def github_actions_test_exists?
-    !github_actions.nil? && github_actions.key?("jobs") && github_actions["jobs"].key?("test")
+  def github_actions_test_job_name
+    test_job = github_actions&.dig("jobs", "test")
+    unless test_job.nil?
+      test_job.fetch("name", "test")
+    end
   end
 
   def github_actions_pre_commit_exists?

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -63,6 +63,16 @@ RSpec.describe ConfigureRepos do
       the_repo_has_branch_protection_activated
       the_repo_is_updated_with_correct_settings
     end
+
+    context "and the test job has a custom name" do
+      it "Uses the custom name" do
+        given_theres_a_repo(full_name: "alphagov/rubocop-govuk")
+        and_the_repo_does_not_have_a_jenkinsfile(full_name: "alphagov/rubocop-govuk")
+        and_the_repo_uses_github_actions_for_test(full_name: "alphagov/rubocop-govuk", job_name: "Run tests")
+        when_the_script_runs
+        the_repo_has_ci_enabled(full_name: "alphagov/rubocop-govuk", providers: ["github_actions"], github_actions: ["Run tests"])
+      end
+    end
   end
 
   context "when a repo uses GitHub Actions for CI and pre-commit" do
@@ -164,11 +174,11 @@ RSpec.describe ConfigureRepos do
       to_return(status: 404)
   end
 
-  def and_the_repo_uses_github_actions_for_test(full_name: "alphagov/govuk-coronavirus-content")
+  def and_the_repo_uses_github_actions_for_test(full_name: "alphagov/govuk-coronavirus-content", job_name: nil)
     content = {
       "on" => %w[push pull_request],
       "jobs" => {
-        "test" => {},
+        "test" => job_name.nil? ? {} : {"name" => job_name},
       }
     }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/sT354wJa/3106-make-govuk-saas-config-test-check-more-robust-3)

Currently, this script checks for the existence of a `test` job in the CI workflow, and makes it a required status check. However, the name of the job can be overridden by adding e.g. `name: Run tests` to the YAML. In this case the script will create a required status check for `test`, when the real name of the job is `Run tests`, which causes GitHub to wait forever for a check that will never complete.

This PR updates the script to use the name of the job (if present) when configuring required status checks.