### PR TITLE
Don't check for GitHub Actions `pre-commit` jobs

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -97,14 +97,13 @@ private
   end
 
   def required_status_checks
-    return nil unless jenkinsfile_exists? || github_actions_exists?
+    return nil unless jenkinsfile_exists? || !github_actions_test_job_name.nil?
 
     {
       strict: overrides.fetch("up_to_date_branches", false),
       contexts: [
         jenkinsfile_exists? ? "continuous-integration/jenkins/branch" : nil,
         github_actions_test_job_name,
-        github_actions_pre_commit_exists? ? "pre-commit" : nil,
         *overrides
           .fetch("required_status_checks", {})
           .fetch("additional_contexts", [])
@@ -140,18 +139,10 @@ private
     end
   end
 
-  def github_actions_exists?
-    !github_actions_test_job_name.nil? || github_actions_pre_commit_exists?
-  end
-
   def github_actions_test_job_name
     test_job = github_actions&.dig("jobs", "test")
     unless test_job.nil?
       test_job.fetch("name", "test")
     end
-  end
-
-  def github_actions_pre_commit_exists?
-    !github_actions.nil? && github_actions.key?("jobs") && github_actions["jobs"].key?("pre-commit")
   end
 end

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -75,19 +75,6 @@ RSpec.describe ConfigureRepos do
     end
   end
 
-  context "when a repo uses GitHub Actions for CI and pre-commit" do
-    it "Updates a repo" do
-      given_theres_a_repo(full_name: "alphagov/rubocop-govuk")
-      and_the_repo_does_not_have_a_jenkinsfile(full_name: "alphagov/rubocop-govuk")
-      and_the_repo_uses_github_actions_for_test_and_pre_commit(full_name: "alphagov/rubocop-govuk")
-      when_the_script_runs
-      the_repo_is_updated_with_correct_settings
-      the_repo_has_branch_protection_activated
-      the_repo_has_ci_enabled(full_name: "alphagov/rubocop-govuk", providers: ["github_actions"], github_actions: %w[test pre-commit])
-      the_repo_has_webhooks_configured(number_of_webhooks: 1)
-    end
-  end
-
   context "when there are no supported CI provider config files" do
     it "doesn't set up CI if there is no Jenkinsfile or GitHub Actions config" do
       given_theres_a_repo
@@ -179,23 +166,6 @@ RSpec.describe ConfigureRepos do
       "on" => %w[push pull_request],
       "jobs" => {
         "test" => job_name.nil? ? {} : {"name" => job_name},
-      }
-    }
-
-    payload = {
-      content: Base64.encode64(content.to_yaml)
-    }
-
-    stub_request(:get, "https://api.github.com/repos/#{full_name}/contents/.github/workflows/ci.yml").
-      to_return(body: payload.to_json, headers: { content_type: "application/json" }, status: 200)
-  end
-
-  def and_the_repo_uses_github_actions_for_test_and_pre_commit(full_name: "alphagov/govuk-coronavirus-content")
-    content = {
-      "on" => %w[push pull_request],
-      "jobs" => {
-        "test" => {},
-        "pre-commit" => {},
       }
     }
 


### PR DESCRIPTION
This was [added to support the govuk-account-manager-prototype](https://github.com/alphagov/govuk-saas-config/commit/ad03c94492aa86e3e5101c294e09c82af3714474), which is now archived (thanks for spotting this @ChrisBAshton)