### PR TITLE
Add support for repos where the CI workflow is named `ci.yaml` 

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -129,14 +129,18 @@ private
     Base64.decode64(jenkinsfile.content)
   end
 
-  def github_actions
-    @github_actions ||= begin
-      encoded_content = client.contents(repo[:full_name], path: ".github/workflows/ci.yml").content
+  def workflow_definition(filename)
+    begin
+      encoded_content = client.contents(repo[:full_name], path: ".github/workflows/#{filename}").content
       decoded_content = Base64.decode64(encoded_content)
       YAML.load(decoded_content)
     rescue Octokit::NotFound
       nil
     end
+  end
+
+  def github_actions
+    @github_actions ||= workflow_definition("ci.yml") || workflow_definition("ci.yaml")
   end
 
   def github_actions_test_job_name


### PR DESCRIPTION
Currently this script sets up required status checks if the CI workflow is named exactly `ci.yml` (and not `ci.yaml` as it’s named on [7 of our repos](https://github.com/search?q=org%3Aalphagov+path%3A.github%2Fworkflows%2Fci.yaml&type=code)).

This PR adds support for repos where the workflow is named `ci.yaml`.

Before merging, it might be a good idea to give the owners of the 7 aforementioned repos a heads-up, as this will change the required status checks for their repos.