### PR TITLE
Making sure GOVUK tagged repos on GitHub are in sync...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 ruby File.read(".ruby-version").chomp
 
-gem 'octokit'
-gem 'rake'
-gem 'rspec'
-gem 'webmock'
-gem 'pry-byebug'
+gem "octokit"
+gem "rake"
+gem "rspec"
+gem "webmock"
+gem "pry-byebug"
+gem "faraday-retry"
+gem "colorize"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     byebug (11.1.3)
     coderay (1.1.3)
+    colorize (0.8.1)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
@@ -12,6 +13,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    faraday-retry (2.1.0)
+      faraday (~> 2.0)
     hashdiff (1.0.1)
     method_source (1.0.0)
     octokit (6.0.1)
@@ -49,10 +52,13 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
+  colorize
+  faraday-retry
   octokit
   pry-byebug
   rake

--- a/github/README.md
+++ b/github/README.md
@@ -16,6 +16,21 @@ Usage (can run on your Mac or within dev VM):
 ```
 GITHUB_TOKEN=xyz bundle exec rake github:configure_repos
 ```
+
+### `rake github:verify_repo_tags`
+
+Will compare the list of currently GOVUK tagged repos on GitHub with the list of repos in devdocs (https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml), then prints a list of untagged and
+falesly tagged repos.
+
+Requires a GitHub personal access token, which can be generated using the [GitHub UI](https://github.com/settings/tokens/new), with full repo scope permissions, otherwise private repositories might
+incorrectly show up as untagged.
+
+Usage (can run on your Mac or within dev VM):
+
+```
+GITHUB_TOKEN=xyz bundle exec rake github:verify_repo_tags
+```
+
 ## How changes get applied
 
 There is a [jenkins job](https://github.com/alphagov/govuk-puppet/blob/02f4971ec60edf6592b02e2c29227aae534dfa4f/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb) configured to run at ~8am every day, which automatically runs the above rake command and applies changes.

--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -1,5 +1,5 @@
-require 'base64'
-require 'yaml'
+require "base64"
+require "yaml"
 
 class ConfigureRepo
   attr_reader :repo, :client

--- a/github/lib/fetch_repos.rb
+++ b/github/lib/fetch_repos.rb
@@ -1,0 +1,20 @@
+require "yaml"
+
+class FetchRepos
+  def initialize(client = nil)
+    @client = client
+  end
+
+  def repos
+    @client
+      .org_repos("alphagov", accept: "application/vnd.github.mercy-preview+json")
+      .select { |repo| repo.topics.to_a.include?("govuk") }
+      .reject { |repo| ignored_repos.include?(repo.full_name) }
+      .reject { |repo| repo.archived }
+      .sort_by { |repo| repo[:full_name] }
+  end
+
+  def ignored_repos
+    @ignored_repos ||= YAML.load_file("#{__dir__}/../ignored_repos.yml")
+  end
+end

--- a/github/lib/validate_repos.rb
+++ b/github/lib/validate_repos.rb
@@ -1,0 +1,46 @@
+require "json"
+require "octokit"
+require "open-uri"
+require "colorize"
+require_relative "./fetch_repos"
+
+class ValidateRepos
+  def initialize(client = nil)
+    Octokit.auto_paginate = true
+    @client = client || Octokit::Client.new(access_token: ENV.fetch("GITHUB_TOKEN"))
+  end
+  
+  def github_repos_tagged_govuk
+    FetchRepos.new(@client).repos
+  end
+
+  def verify_repo_tags
+    govuk_repo_names = JSON.load(URI.open("https://docs.publishing.service.gov.uk/repos.json")).map { |repo| repo["app_name"] }
+    github_repo_names = github_repos_tagged_govuk.map { |repo| repo["name"] }
+    
+    untagged_govuk_repo_names = govuk_repo_names - github_repo_names
+    falsely_tagged_govuk_repo_names = github_repo_names - govuk_repo_names
+    
+    if untagged_govuk_repo_names.empty?
+      puts "Untagged govuk repos: No mismatches found.".colorize(:color => :green, :background => :black)
+    
+    else
+      puts "Untagged govuk repos:".colorize(:color => :red, :background => :black)
+      untagged_govuk_repo_names.each do |untag|
+        puts untag
+      end
+    end  
+
+    puts "\n"
+
+    if falsely_tagged_govuk_repo_names.empty?
+      puts "Falsely tagged govuk repos: No mismatches found.".colorize(:color => :green, :background => :black)
+    
+    else
+      puts "Falsely tagged govuk repos:".colorize(:color => :red, :background => :black)
+      falsely_tagged_govuk_repo_names.each do |falsetag|
+        puts falsetag
+      end
+    end
+  end
+end

--- a/github/spec/features/validate_repos_spec.rb
+++ b/github/spec/features/validate_repos_spec.rb
@@ -1,0 +1,57 @@
+require_relative "../spec_helper"
+require_relative "../../lib/validate_repos"
+
+RSpec.describe ValidateRepos do
+
+  before do
+    @repo_mock = double("Repo", topics: ["govuk"], archived: false)
+    allow(@repo_mock).to receive(:[]).with("name").and_return("this-is-a-govuk-repo")
+    allow(@repo_mock).to receive(:full_name).and_return("this-is-a-govuk-repo")
+    allow(@repo_mock).to receive(:[]).with(:full_name).and_return("this-is-a-govuk-repo")
+    @octokit_mock = double("Octokit::Client", org_repos: [@repo_mock])
+  end
+
+  it "should ignore any repos that exist in repos.json AND are tagged govuk in GitHub" do
+    repos = [{
+      "app_name": "this-is-a-govuk-repo",
+    }]
+
+    stub_repos_json(repos)
+
+    expect { ValidateRepos.new(@octokit_mock).verify_repo_tags }.to output("\e[0;32;40mUntagged govuk repos: No mismatches found.\e[0m\n\n\e[0;32;40mFalsely tagged govuk repos: No mismatches found.\e[0m\n").to_stdout
+  end
+
+  it "should alert if finds an untagged repo in repos.json" do
+    repos = [
+      { "app_name": "this-is-a-govuk-repo", },
+      { "app_name": "this-govuk-repo-is-not-tagged!", }
+    ]
+
+    stub_repos_json(repos)
+
+    expect { ValidateRepos.new(@octokit_mock).verify_repo_tags }.to output("\e[0;31;40mUntagged govuk repos:\e[0m\nthis-govuk-repo-is-not-tagged!\n\n\e[0;32;40mFalsely tagged govuk repos: No mismatches found.\e[0m\n").to_stdout
+  end
+
+  it "should alert if it finds a repo that has falsely been tagged as govuk." do
+    repos = []
+
+    stub_repos_json(repos)
+
+    expect { ValidateRepos.new(@octokit_mock).verify_repo_tags }.to output("\e[0;32;40mUntagged govuk repos: No mismatches found.\e[0m\n\n\e[0;31;40mFalsely tagged govuk repos:\e[0m\nthis-is-a-govuk-repo\n").to_stdout
+  end
+
+  it "should alert reports findings accordingly and appropriately when it finds both." do
+    repos = [{
+      "app_name": "this-govuk-repo-is-not-tagged!", 
+    }]
+
+    stub_repos_json(repos)
+
+    expect { ValidateRepos.new(@octokit_mock).verify_repo_tags }.to output("\e[0;31;40mUntagged govuk repos:\e[0m\nthis-govuk-repo-is-not-tagged!\n\n\e[0;31;40mFalsely tagged govuk repos:\e[0m\nthis-is-a-govuk-repo\n").to_stdout
+  end
+
+  def stub_repos_json(repos)
+    stub_request(:get, "https://docs.publishing.service.gov.uk/repos.json").
+      to_return(status: 200, body: repos.to_json, headers: {})
+  end
+end

--- a/github/tasks.rake
+++ b/github/tasks.rake
@@ -1,4 +1,5 @@
-require_relative 'lib/configure_repos'
+require_relative "lib/configure_repos"
+require_relative "lib/validate_repos"
 
 namespace :github do
   desc "Configure the repos with correct settings and branch protection"
@@ -14,5 +15,10 @@ namespace :github do
   desc "Remove old webhooks"
   task :remove_old_webhooks do
     ConfigureRepos.new.remove_old_webhooks!
+  end
+
+  desc "Verify that GOVUK repos are tagged #govuk"
+  task :verify_repo_tags do
+    ValidateRepos.new.verify_repo_tags
   end
 end


### PR DESCRIPTION
...with the repos.yml data of the devdocs.

A script checking both sources and highlighting repositories where they are in the devdocs repos.yml list, but aren't tagged GOVUK on GitHub, and repos tagged GOVUK which are not listed in the yml list.

- Put repo fetching methods in a separate file and referenced them where required, existing tests pass.
- Created comparison methods for tagged repos and devdocs repo list
- Added colorised print for easier readability
- Updated README
- Added script to rake tasks
- Created tests for 4 scenarios to account for all  possible outcomes.

Trello card: https://trello.com/c/x7rPEBID/3095-making-sure-the-repositories-tagged-as-govuk-on-github-are-in-sync-with-the-reposyml-data