### PR TITLE
Manually set correct branch required checks for EKS apps

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -99,10 +99,12 @@ private
   def required_status_checks
     return nil unless jenkinsfile_exists? || !github_actions_test_job_name.nil?
 
+    enforce_jenkins_checks = jenkinsfile_exists? && !overrides.dig("required_status_checks", "ignore_jenkins")
+
     {
       strict: overrides.fetch("up_to_date_branches", false),
       contexts: [
-        jenkinsfile_exists? ? "continuous-integration/jenkins/branch" : nil,
+        enforce_jenkins_checks ? "continuous-integration/jenkins/branch" : nil,
         github_actions_test_job_name,
         *overrides
           .fetch("required_status_checks", {})

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -12,56 +12,124 @@ alphagov/account-api:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
+      - Run Pact tests / Verify pact tests
 
 alphagov/asset-manager:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Lint Ruby / Run RuboCop
+      - Run Pact tests / Verify pact tests
+      - Security Analysis / Run Brakeman
 
 alphagov/authenticating-proxy:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
 
 alphagov/bouncer:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Lint Ruby / Run RuboCop
 
 alphagov/collections:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Integration tests
+      - Lint Ruby / Run RuboCop
+      - Lint JavaScript / Run Standardx
+      - Lint SCSS / Run Stylelint
+      - Security Analysis / Run Brakeman
+      - Run Pact tests / Verify pact tests
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run RSpec
 
 alphagov/cache-clearing-service:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
+      - Test Ruby / Run RSpec
 
 alphagov/collections-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
+      - Lint JavaScript / Run Standardx
+      - Lint SCSS / Run Stylelint
+      - Test Ruby / Run RSpec
 
 alphagov/contacts-admin:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
+      - Lint JavaScript / Run Standardx
+      - Lint SCSS / Run Stylelint
+      - Test Ruby / Run RSpec
 
 alphagov/content-data-api:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
+      - Test Ruby / Run RSpec
 
 alphagov/content-store:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Run Pact tests / Verify pact tests
+      - Security Analysis / Run Brakeman
+      - Test Ruby / Run RSpec
 
 alphagov/content-tagger:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Security Analysis / Run Brakeman
+      - Lint SCSS / Run Stylelint
+      - Lint Ruby / Run RuboCop
+      - Lint JavaScript / Run Standardx
+      - Test Ruby / Run RSpec
 
 alphagov/data-community-tech-docs:
   allow_squash_merge: true
@@ -73,26 +141,61 @@ alphagov/email-alert-api:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Run Pact tests / Verify pact tests
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
 
 alphagov/email-alert-frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
+      - Lint SCSS / Run Stylelint
+      - Lint JavaScript / Run Standardx
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run RSpec
 
 alphagov/email-alert-service:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Test Ruby / Run RSpec
 
 alphagov/feedback:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
+      - Lint JavaScript / Run Standardx
+      - Lint SCSS / Run Stylelint
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run RSpec
 
 alphagov/frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Lint JavaScript / Run Standardx
+      - Run Pact tests / Verify pact tests
+      - Lint SCSS / Run Stylelint
+      - Security Analysis / Run Brakeman
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run Minitest
 
 alphagov/govuk-content-api-docs:
   allow_squash_merge: true
@@ -107,82 +210,193 @@ alphagov/imminence:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Integration tests
+      - Test Ruby
+      - Lint Ruby / Run RuboCop
+      - Run Pact tests / Verify pact tests
+      - Security Analysis / Run Brakeman
 
 alphagov/link-checker-api:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
+      - Run Pact tests / Verify pact tests
 
 alphagov/local-links-manager:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Lint Ruby / Run RuboCop
+      - Lint JavaScript / Run Standardx
+      - Lint SCSS / Run Stylelint
+      - Security Analysis / Run Brakeman
 
 alphagov/locations-api:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
+      - Run Pact tests / Verify pact tests
 
 alphagov/release:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
+      - Lint JavaScript / Run Standardx
+      - Lint SCSS / Run Stylelint
 
 alphagov/short-url-manager:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
+      - Test Ruby / Run RSpec
+      - Lint SCSS / Run Stylelint
 
 alphagov/smart-answers:
   allow_squash_merge: true
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint JavaScript / Run Standardx
+      - Security Analysis / Run Brakeman
+      - Lint SCSS / Run Stylelint
+      - Lint Ruby / Run RuboCop
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run Minitest
 
 alphagov/specialist-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Lint JavaScript / Run Standardx
+      - Security Analysis / Run Brakeman
+      - Lint SCSS / Run Stylelint
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run RSpec
 
 alphagov/support-api:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
 
 alphagov/travel-advice-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
+      - Lint SCSS / Run Stylelint
+      - Lint JavaScript / Run Standardx
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run RSpec
 
 alphagov/publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Security Analysis / Run Brakeman
+      - Lint JavaScript / Run Standardx
+      - Lint Ruby / Run RuboCop
+      - Lint SCSS / Run Stylelint
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run Minitest
 
 alphagov/publishing-api:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Check content schemas are built
+      - Test Ruby
+      - Lint Ruby / Run RuboCop
+      - Run GDS API Adapter Pact tests / Verify pact tests
+      - Security Analysis / Run Brakeman
+      - Run Content Store Pact tests / Verify pact tests
 
 alphagov/finder-frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Integration tests
+      - Lint Ruby / Run RuboCop
+      - Lint SCSS / Run Stylelint
+      - Security Analysis / Run Brakeman
+      - Lint JavaScript / Run Standardx
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run RSpec
 
 alphagov/government-frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
+      - Lint SCSS / Run Stylelint
+      - Lint JavaScript / Run Standardx
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run Minitest
 
 alphagov/hmrc-manuals-api:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Test Ruby / Run Minitest
+      - Security Analysis / Run Brakeman
 
 alphagov/licence-finder:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
+      - Test Ruby / Run RSpec
 
 alphagov/manuals-frontend:
   # required for continuous deployment
@@ -193,26 +407,63 @@ alphagov/manuals-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Integration tests
+      - Lint JavaScript / Run Standardx
+      - Lint Ruby / Run RuboCop
+      - Lint SCSS / Run Stylelint
+      - Security Analysis / Run Brakeman
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run RSpec
 
 alphagov/maslow:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Lint Ruby / Run RuboCop
+      - Lint JavaScript / Run Standardx
+      - Lint SCSS / Run Stylelint
+      - Security Analysis / Run Brakeman
+      - Test JavaScript / Run Jasmine
 
 alphagov/info-frontend:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint Ruby / Run RuboCop
+      - Test Ruby / Run RSpec
+      - Security Analysis / Run Brakeman
 
 alphagov/content-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Lint SCSS / Run Stylelint
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
+      - Lint JavaScript / Run Standardx
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run RSpec
 
 alphagov/content-data-admin:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Lint SCSS / Run Stylelint
+      - Lint JavaScript / Run Standardx
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
 
 alphagov/service-manual-frontend:
   # required for continuous deployment
@@ -223,6 +474,14 @@ alphagov/service-manual-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
+      - Lint SCSS / Run Stylelint
+      - Lint JavaScript / Run Standardx
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run RSpec
 
 alphagov/sidekiq-monitoring:
   # required for continuous deployment
@@ -233,24 +492,94 @@ alphagov/signon:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Lint JavaScript / Run Standardx
+      - Lint Ruby / Run RuboCop
+      - Lint SCSS / Run Stylelint
+      - Security Analysis / Run Brakeman
+      - Test JavaScript / Run Jasmine
 
 alphagov/support:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Lint JavaScript / Run Standardx
+      - Lint SCSS / Run Stylelint
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
 
 alphagov/transition:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Integration tests
+      - Test Ruby
+      - Lint Ruby / Run RuboCop
+      - Security Analysis / Run Brakeman
+      - Test JavaScript / Run Jasmine
 
 alphagov/whitehall:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Integration tests
+      - Lint SCSS / Run Stylelint
+      - Lint JavaScript / Run Standardx
+      - Lint Ruby / Run RuboCop
+      - Run Pact tests / Verify pact tests
+      - Security Analysis / Run Brakeman
+      - Test JavaScript / Run Jasmine
+      - Test Ruby / Run Minitest
 
 alphagov/govuk-coronavirus-content:
   allow_squash_merge: true
 
 alphagov/repo-for-govuk-saas-config-automated-tests:
   up_to_date_branches: true
+
+alphagov/router-api:
+  need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Security Analysis / Run Brakeman
+      - Lint Ruby / Run RuboCop
+
+alphagov/search-admin:
+  need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Integration tests
+      - Lint Ruby / Run RuboCop
+      - Lint JavaScript / Run Standardx
+      - Lint SCSS / Run Stylelint
+      - Security Analysis / Run Brakeman
+      - Test Ruby / Run RSpec
+
+alphagov/search-api:
+  need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Check Learn to Rank dependencies
+      - Lint Ruby / Run RuboCop
+      - Test Ruby / Run RSpec
+
+alphagov/static:
+  need_production_access_to_merge: true
+  required_status_checks:
+    additional_contexts:
+      - Test Ruby
+      - Lint Ruby / Run RuboCop
+      - Lint JavaScript / Run Standardx
+      - Lint SCSS / Run Stylelint
+      - Security Analysis / Run Brakeman
+      - Test JavaScript / Run Jasmine

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -13,6 +13,7 @@ alphagov/account-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Lint Ruby / Run RuboCop
@@ -24,6 +25,7 @@ alphagov/asset-manager:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Lint Ruby / Run RuboCop
@@ -35,6 +37,7 @@ alphagov/authenticating-proxy:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Security Analysis / Run Brakeman
@@ -45,6 +48,7 @@ alphagov/bouncer:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Lint Ruby / Run RuboCop
@@ -54,6 +58,7 @@ alphagov/collections:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Integration tests
       - Lint Ruby / Run RuboCop
@@ -69,6 +74,7 @@ alphagov/cache-clearing-service:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
@@ -79,6 +85,7 @@ alphagov/collections-publisher:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
@@ -91,6 +98,7 @@ alphagov/contacts-admin:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
@@ -103,6 +111,7 @@ alphagov/content-data-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
@@ -113,6 +122,7 @@ alphagov/content-store:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Run Pact tests / Verify pact tests
@@ -124,6 +134,7 @@ alphagov/content-tagger:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Security Analysis / Run Brakeman
       - Lint SCSS / Run Stylelint
@@ -142,6 +153,7 @@ alphagov/email-alert-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Run Pact tests / Verify pact tests
@@ -153,6 +165,7 @@ alphagov/email-alert-frontend:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
@@ -166,6 +179,7 @@ alphagov/email-alert-service:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Test Ruby / Run RSpec
@@ -175,6 +189,7 @@ alphagov/feedback:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
@@ -188,6 +203,7 @@ alphagov/frontend:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Lint JavaScript / Run Standardx
@@ -211,6 +227,7 @@ alphagov/imminence:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Integration tests
       - Test Ruby
@@ -223,6 +240,7 @@ alphagov/link-checker-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Security Analysis / Run Brakeman
@@ -234,6 +252,7 @@ alphagov/local-links-manager:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Lint Ruby / Run RuboCop
@@ -246,6 +265,7 @@ alphagov/locations-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Security Analysis / Run Brakeman
@@ -257,6 +277,7 @@ alphagov/release:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Lint Ruby / Run RuboCop
@@ -269,6 +290,7 @@ alphagov/short-url-manager:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
@@ -281,6 +303,7 @@ alphagov/smart-answers:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint JavaScript / Run Standardx
       - Security Analysis / Run Brakeman
@@ -294,6 +317,7 @@ alphagov/specialist-publisher:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Lint JavaScript / Run Standardx
@@ -307,6 +331,7 @@ alphagov/support-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Security Analysis / Run Brakeman
@@ -317,6 +342,7 @@ alphagov/travel-advice-publisher:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
@@ -330,6 +356,7 @@ alphagov/publisher:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Security Analysis / Run Brakeman
       - Lint JavaScript / Run Standardx
@@ -343,6 +370,7 @@ alphagov/publishing-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Check content schemas are built
       - Test Ruby
@@ -356,6 +384,7 @@ alphagov/finder-frontend:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Integration tests
       - Lint Ruby / Run RuboCop
@@ -370,6 +399,7 @@ alphagov/government-frontend:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
@@ -383,6 +413,7 @@ alphagov/hmrc-manuals-api:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Test Ruby / Run Minitest
@@ -393,6 +424,7 @@ alphagov/licence-finder:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
@@ -408,6 +440,7 @@ alphagov/manuals-publisher:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Integration tests
       - Lint JavaScript / Run Standardx
@@ -422,6 +455,7 @@ alphagov/maslow:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Lint Ruby / Run RuboCop
@@ -435,6 +469,7 @@ alphagov/info-frontend:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Test Ruby / Run RSpec
@@ -445,6 +480,7 @@ alphagov/content-publisher:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Lint SCSS / Run Stylelint
       - Security Analysis / Run Brakeman
@@ -458,6 +494,7 @@ alphagov/content-data-admin:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Lint SCSS / Run Stylelint
@@ -475,6 +512,7 @@ alphagov/service-manual-publisher:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
@@ -493,6 +531,7 @@ alphagov/signon:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Lint JavaScript / Run Standardx
@@ -506,6 +545,7 @@ alphagov/support:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Lint JavaScript / Run Standardx
@@ -518,6 +558,7 @@ alphagov/transition:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Integration tests
       - Test Ruby
@@ -530,6 +571,7 @@ alphagov/whitehall:
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Integration tests
       - Lint SCSS / Run Stylelint
@@ -549,6 +591,7 @@ alphagov/repo-for-govuk-saas-config-automated-tests:
 alphagov/router-api:
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Security Analysis / Run Brakeman
@@ -557,6 +600,7 @@ alphagov/router-api:
 alphagov/search-admin:
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Integration tests
       - Lint Ruby / Run RuboCop
@@ -568,6 +612,7 @@ alphagov/search-admin:
 alphagov/search-api:
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Check Learn to Rank dependencies
       - Lint Ruby / Run RuboCop
@@ -576,6 +621,7 @@ alphagov/search-api:
 alphagov/static:
   need_production_access_to_merge: true
   required_status_checks:
+    ignore_jenkins: true
     additional_contexts:
       - Test Ruby
       - Lint Ruby / Run RuboCop

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -90,11 +90,11 @@ RSpec.describe ConfigureRepos do
 
   context "when a repo uses both Jenkins and GitHub Actions for CI" do
     it "sets up CI for both providers" do
-      given_theres_a_repo(full_name: "alphagov/static")
-      and_the_repo_has_a_jenkinsfile(full_name: "alphagov/static")
-      and_the_repo_uses_github_actions_for_test(full_name: "alphagov/static")
+      given_theres_a_repo(full_name: "alphagov/example")
+      and_the_repo_has_a_jenkinsfile(full_name: "alphagov/example")
+      and_the_repo_uses_github_actions_for_test(full_name: "alphagov/example")
       when_the_script_runs
-      the_repo_has_ci_enabled(full_name: "alphagov/static", providers: ["jenkins", "github_actions"])
+      the_repo_has_ci_enabled(full_name: "alphagov/example", providers: ["jenkins", "github_actions"])
       the_repo_has_branch_protection_activated
       the_repo_is_updated_with_correct_settings
     end


### PR DESCRIPTION
For applications migrated to EKS, we no longer need to required checks for Jenkins CI. Instead we need the CI workflow on GitHub Actions to pass. For now I've added manual configuration - as it's not straightforward to generate the check names for a workflow file nor is there an easy API to access this information.

This just disables the Jenkins CI check, rather than removing the Jenkinsfile from the associated repos - incase we still need to deploy to EC2.