### PR TITLE
Remove travis-ci from required checks for datagovuk_find and _publish

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -1,13 +1,3 @@
-alphagov/datagovuk_find:
-  required_status_checks:
-    additional_contexts:
-      - continuous-integration/travis-ci
-
-alphagov/datagovuk_publish:
-  required_status_checks:
-    additional_contexts:
-      - continuous-integration/travis-ci
-
 alphagov/account-api:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
Travis was replaces by Github actions and removed in:

- https://github.com/alphagov/datagovuk_find/pull/960
- https://github.com/alphagov/datagovuk_publish/pull/1076

The status on branch check is pending blocking deployments.