### PR TITLE
Enable vulnerability alerts and automated security fixes for all repos

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -15,6 +15,8 @@ class ConfigureRepo
     update_repo_settings
     protect_branch
     update_webhooks
+    enable_vulnerability_alerts
+    enable_automated_security_fixes
     puts "√ #{repo[:full_name]}"
   rescue Octokit::NotFound => e
     puts "Could not find #{repo[:full_name]}. Possibly the govuk-ci user doesn't have admin access to this repo."
@@ -146,5 +148,13 @@ private
     unless test_job.nil?
       test_job.fetch("name", "test")
     end
+  end
+  
+  def enable_vulnerability_alerts
+    client.enable_vulnerability_alerts(repo[:full_name])
+  end
+
+  def enable_automated_security_fixes
+    client.put("https://api.github.com/repos/#{repo[:full_name]}/automated-security-fixes", accept: "application/vnd.github+json")
   end
 end


### PR DESCRIPTION
Enable vulnerability alerts and automated security fixes for all GOV.UK repos

This adds functionality to the `configure_repo.rb` script to enable vulnerability alerts and automated security fixes for all GOV.UK repositories. This ensures that Dependabot PRs will be raised for security vulnerabilities automatically.

The motivation for this change came from the discovery that some GOV.UK repositories, such as govuk-rota-announcer, did not have Dependabot PRs raised for security vulnerabilities. By enabling the "Dependabot security updates" setting automatically via govuk-saas-config, we can address this issue and ensure that all repositories are kept up to date with regard to security vulnerabilities.

This change will help to prevent potential security issues and reduce the time spent manually enabling these settings for each repository.

[Trello](https://trello.com/c/Om7GS3Uk/3127-explore-auto-enabling-dependabot-security-updates-on-all-govuk-repos-2)