### PR TITLE
Add Router-Postgres to the Repo-Overrides

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -585,6 +585,13 @@ alphagov/router:
     additional_contexts:
      - Test Go
 
+alphagov/router-postgres:
+  need_production_access_to_merge: true
+  required_status_checks:
+    ignore_jenkins: true
+    additional_contexts:
+     - Test Go
+
 alphagov/router-api:
   need_production_access_to_merge: true
   required_status_checks:


### PR DESCRIPTION
We're migrating Router to Postgres and the new fork needs to be covered by the relevant permissions and tests.

https://trello.com/c/YJro3BGj/1790-spin-up-a-separate-stack-of-router-l