### PR TITLE
Removed reference to cache-clearing-service

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -59,17 +59,6 @@ alphagov/collections:
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run RSpec
 
-alphagov/cache-clearing-service:
-  # required for continuous deployment
-  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
-  need_production_access_to_merge: true
-  required_status_checks:
-    ignore_jenkins: true
-    additional_contexts:
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      - Test Ruby / Run RSpec
-
 alphagov/collections-publisher:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks


### PR DESCRIPTION
Removed reference to cache-clearing-service as the application has been retired.

https://trello.com/c/ENPwB2vT/41-retire-cache-clearing-service

https://trello.com/c/TX9wLihh/101-cache-clearing-app-exists-and-we-dont-think-its-necessary-replacing-cache-clearing-app-only-clears-path-not-query-strings