### PR TITLE
Refactor verify repo tags

### DIFF
--- a/.github/workflows/verify-repo-tags.yml
+++ b/.github/workflows/verify-repo-tags.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  configure-github:
+  verify-repo-tags:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -22,13 +22,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          output=$(bundle exec rake github:verify_repo_tags)
+          EXIT_CODE=0
+          output=$(bundle exec rake github:verify_repo_tags) || EXIT_CODE=$?
 
-          untagged_repos=$(echo "$output" | grep 'Untagged govuk repos:' -A 1 | tail -n +2)
-          falsely_tagged_repos=$(echo "$output" | grep 'Falsely tagged govuk repos:' -A 1 | tail -n +2)
+          echo "$output"
 
-          echo "untagged_repos=$untagged_repos" >> "$GITHUB_OUTPUT"
-          echo "falsely_tagged_repos=$falsely_tagged_repos" >> "$GITHUB_OUTPUT"
+          exit $EXIT_CODE
 
       - name: Notify failure
         uses: slackapi/slack-github-action@v1
@@ -52,20 +51,6 @@ jobs:
                     },
                     "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                     "action_id": "button-view-workflow"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Untagged govuk repos:\n${{ steps.verify_repo_tags.outputs.UNTAGGED_REPOS }}"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Falsely tagged govuk repos:\n${{ steps.verify_repo_tags.outputs.FALSELY_TAGGED_REPOS }}"
                   }
                 }
               ]

--- a/github/lib/validate_repos.rb
+++ b/github/lib/validate_repos.rb
@@ -10,19 +10,18 @@ class ValidateRepos
   end
   
   def github_repos_tagged_govuk
-    FetchRepos.new(@client).repos
+    @github_repos_tagged_govuk ||= FetchRepos.new(@client).repos.map { |repo| repo["name"] }
   end
 
-  def verify_repo_tags
-    govuk_repo_names = JSON.load(URI.open("https://docs.publishing.service.gov.uk/repos.json")).map { |repo| repo["app_name"] }
-    github_repo_names = github_repos_tagged_govuk.map { |repo| repo["name"] }
-      
-    untagged_repos = (govuk_repo_names - github_repo_names).join("\n")
-    falsely_tagged_repos = (github_repo_names - govuk_repo_names).join("\n")
-  
-    puts "Untagged govuk repos:\n#{untagged_repos}" unless untagged_repos.empty?
-    puts "Falsely tagged govuk repos:\n#{falsely_tagged_repos}" unless falsely_tagged_repos.empty?
+  def govuk_repo_names
+    @govuk_repo_names ||= JSON.load(URI.open("https://docs.publishing.service.gov.uk/repos.json")).map { |repo| repo["app_name"] }
+  end
 
-    exit 1 unless untagged_repos.empty? && falsely_tagged_repos.empty?
+  def untagged_repos
+    (govuk_repo_names - github_repos_tagged_govuk).join("\n")
+  end
+
+  def falsely_tagged_repos
+    (github_repos_tagged_govuk - govuk_repo_names).join("\n")
   end
 end

--- a/github/spec/features/validate_repos_spec.rb
+++ b/github/spec/features/validate_repos_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe ValidateRepos do
 
     stub_repos_json(repos)
 
-    expect { ValidateRepos.new(@octokit_mock).verify_repo_tags }.to_not output.to_stdout
+    validator = ValidateRepos.new(@octokit_mock)
+
+    expect(validator.untagged_repos).to eq("")
+    expect(validator.falsely_tagged_repos).to eq("")
   end
 
   it "should alert if finds an untagged repo in repos.json" do
@@ -29,7 +32,10 @@ RSpec.describe ValidateRepos do
 
     stub_repos_json(repos)
 
-    expect { ValidateRepos.new(@octokit_mock).verify_repo_tags }.to output("Untagged govuk repos:\nthis-govuk-repo-is-not-tagged!\n").to_stdout.and raise_error(SystemExit)
+    validator = ValidateRepos.new(@octokit_mock)
+
+    expect(validator.untagged_repos).to eq("this-govuk-repo-is-not-tagged!")
+    expect(validator.falsely_tagged_repos).to eq("")
   end
 
   it "should alert if it finds a repo that has falsely been tagged as govuk." do
@@ -37,17 +43,10 @@ RSpec.describe ValidateRepos do
 
     stub_repos_json(repos)
 
-    expect { ValidateRepos.new(@octokit_mock).verify_repo_tags }.to output("Falsely tagged govuk repos:\nthis-is-a-govuk-repo\n").to_stdout.and raise_error(SystemExit)
-  end
+    validator = ValidateRepos.new(@octokit_mock)
 
-  it "should alert reports findings accordingly and appropriately when it finds both." do
-    repos = [{
-      "app_name": "this-govuk-repo-is-not-tagged!", 
-    }]
-
-    stub_repos_json(repos)
-
-    expect { ValidateRepos.new(@octokit_mock).verify_repo_tags }.to output("Untagged govuk repos:\nthis-govuk-repo-is-not-tagged!\nFalsely tagged govuk repos:\nthis-is-a-govuk-repo\n").to_stdout.and raise_error(SystemExit)
+    expect(validator.falsely_tagged_repos).to eq("this-is-a-govuk-repo")
+    expect(validator.untagged_repos).to eq("")
   end
 
   def stub_repos_json(repos)

--- a/github/tasks.rake
+++ b/github/tasks.rake
@@ -19,6 +19,11 @@ namespace :github do
 
   desc "Verify that GOVUK repos are tagged #govuk"
   task :verify_repo_tags do
-    ValidateRepos.new.verify_repo_tags
+    validator = ValidateRepos.new
+
+    puts "Untagged govuk repos:\n#{validator.untagged_repos}" unless validator.untagged_repos.empty?
+    puts "Falsely tagged govuk repos:\n#{validator.falsely_tagged_repos}" unless validator.falsely_tagged_repos.empty?
+
+    exit 1 unless validator.untagged_repos.empty? && validator.falsely_tagged_repos.empty?
   end
 end


### PR DESCRIPTION
This refactor was needed for the output to show in the GitHub Action and for the Slack notification to show correctly.

https://trello.com/c/bXKnsdeQ/3248-run-verifyrepotags-script-regularly