### PR TITLE
Remove pact test requirement for Whitehall

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -556,7 +556,6 @@ alphagov/whitehall:
       - Lint SCSS / Run Stylelint
       - Lint JavaScript / Run Standardx
       - Lint Ruby / Run RuboCop
-      - Run Pact tests / Verify pact tests
       - Security Analysis / Run Brakeman
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run Minitest


### PR DESCRIPTION
The pact test workflow was removed in https://github.com/alphagov/whitehall/pull/8029, so we no longer need to verify they have run.

[Trello card](https://trello.com/c/jJ0SH0N3)