### PR TITLE
Improve call-to-action around repo validation

### DIFF
--- a/.github/workflows/verify-repo-tags.yml
+++ b/.github/workflows/verify-repo-tags.yml
@@ -35,19 +35,19 @@ jobs:
         with:
           payload: |
             {
-              "text": "Verify Repo Tags: Unresolved issues found. Check the build logs for details.",
+              "text": "The <https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml|Developer Docs repo list> is out of sync with the repos tagged as 'govuk' in GitHub.",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Verify Repo Tags: Unresolved issues found. Check the build logs for details."
+                    "text": "The <https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml|Developer Docs repo list> is out of sync with the repos tagged as 'govuk' in GitHub.",
                   },
                   "accessory": {
                     "type": "button",
                     "text": {
                         "type": "plain_text",
-                        "text": "View"
+                        "text": "Check the build logs for details"
                     },
                     "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                     "action_id": "button-view-workflow"


### PR DESCRIPTION
The frontloading of “Verify” made me think of the Verify programme (rather than GOV.UK), which I suspect might cause some confusion. This new copy is clearer about what the script is complaining about, and has a more accessible button name.