### PR TITLE
Update Whitehall branch rules

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -552,7 +552,7 @@ alphagov/whitehall:
   required_status_checks:
     ignore_jenkins: true
     additional_contexts:
-      - Integration tests
+      - Test features / Run Cucumber
       - Lint SCSS / Run Stylelint
       - Lint JavaScript / Run Standardx
       - Lint Ruby / Run RuboCop


### PR DESCRIPTION
### Do not merge before https://github.com/alphagov/whitehall/pull/8364

# What
Updates the Whitehall branch rules to add `Test features / Run Cucumber` and remove `Integration tests` from the list of required checks

# Why
The Publishing Experience team have made some [changes to the Whitehall CI pipeline](https://trello.com/c/IS5QUoaK/1757-split-and-parallelise-minitest-and-cucumber-jobs-in-ci), which has resulted in the integration workflow being renamed to `Test features / Run Cucumber`. 

See the following pull requests for context:
- https://github.com/alphagov/whitehall/pull/8348
- https://github.com/alphagov/whitehall/pull/8364
- https://github.com/alphagov/whitehall/pull/8365