### PR TITLE
Don't run verify-repo-tags on weekends

### DIFF
--- a/.github/workflows/verify-repo-tags.yml
+++ b/.github/workflows/verify-repo-tags.yml
@@ -2,7 +2,7 @@ name: "Verify Repo Tags"
 
 on:
   schedule:
-    - cron:  '0 9 * * *'
+    - cron:  '0 9 * * 1-5'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
Update the cron job so it doesn't run on weekends.