### PR TITLE
hmrc-manuals-api testsuite is rspec, not minitest.

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -395,7 +395,7 @@ alphagov/hmrc-manuals-api:
     ignore_jenkins: true
     additional_contexts:
       - Lint Ruby / Run RuboCop
-      - Test Ruby / Run Minitest
+      - Test Ruby / Run RSpec
       - Security Analysis / Run Brakeman
 
 alphagov/licence-finder:


### PR DESCRIPTION
- https://github.com/alphagov/hmrc-manuals-api/pull/872