### PR TITLE
Enfore production deploy access for search v2

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -622,8 +622,7 @@ alphagov/search-api:
 alphagov/search-api-v2:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
-  # TODO: Enable me before going live with AB test (~ mid Dec 2023 or early Jan 2024)
-  # need_production_access_to_merge: true
+  need_production_access_to_merge: true
   required_status_checks:
     ignore_jenkins: true
     additional_contexts:
@@ -631,11 +630,15 @@ alphagov/search-api-v2:
       - Lint Ruby / Run RuboCop
       - Test Ruby
 
+alphagov/search-v2-evaluator:
+  # required for continuous deployment
+  # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
+  need_production_access_to_merge: true
+
 alphagov/search-v2-infrastructure:
   # required for continuous deployment
   # https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#security-checks
-  # TODO: Enable me before going live with AB test (~ mid Dec 2023 or early Jan 2024)
-  # need_production_access_to_merge: true
+  need_production_access_to_merge: true
   required_status_checks:
     ignore_jenkins: true
     additional_contexts:


### PR DESCRIPTION
- Add missing `search-v2-evaluator` repo
- Enforce production access for all search v2 repos