### PR TITLE
Require up-to-date branch on merge for Terraform GitOps repos.

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -204,8 +204,17 @@ alphagov/govuk-aws:
 alphagov/govuk-content-api-docs:
   allow_squash_merge: true
 
+alphagov/govuk-dns-tf:
+  up_to_date_branches: true
+
 alphagov/govuk-developer-docs:
   allow_squash_merge: true
+
+alphagov/govuk-fastly:
+  up_to_date_branches: true
+
+alphagov/govuk-fastly-secrets:
+  up_to_date_branches: true
 
 alphagov/govuk-kubernetes-cluster-user-docs:
   allow_squash_merge: true


### PR DESCRIPTION
Generally this is best avoided because it's inconvenient, but for continuously-deployed / GitOps-style Terraform repos it's the lesser of evils because otherwise the pre-merge diff can be confusing if the author forgets to update/rebase their PR branch. (And we really want people to use and trust the pre-merge diff, because this is Terraform we're dealing with.)

We've had this set via the UI before, but it was far from obvious that govuk-saas-config was unsetting it again even though the option wasn't specified either way for these repos in its config here.