### PR TITLE
Fix questionable URL matching.

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -71,7 +71,7 @@ private
     existing_webhooks = client.hooks(repo[:full_name])
 
     # GitHub Trello Poster
-    if existing_webhooks.map(&:config).map(&:url).include?("https://govuk-github-trello-poster.herokuapp.com/payload")
+    if existing_webhooks.map(&:config).map(&:url).start_with?("https://govuk-github-trello-poster.herokuapp.com/")
       puts "√ GitHub Trello Poster webhook exists"
     else
       puts "Creating GitHub Trello Poster webhook"


### PR DESCRIPTION
This isn't a vuln, but the CodeQL rules flag it as a weakness and it's trivial to just write what we really mean and that'll also fix the warning.

Fixes https://github.com/alphagov/govuk-saas-config/security/code-scanning/1