### PR TITLE
Fix applying branch protection when only overrides

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -91,8 +91,6 @@ private
   end
 
   def required_status_checks
-    return if github_actions_test_job_name.nil?
-
     {
       strict: overrides.fetch("up_to_date_branches", false),
       contexts: [

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -52,21 +52,6 @@ RSpec.describe ConfigureRepos do
     end
   end
 
-  context "when there are no supported CI provider config files" do
-    it "doesn't set up CI if there is no GitHub Actions config" do
-      given_theres_a_repo
-      and_the_repo_does_not_use_github_actions
-      when_the_script_runs
-      the_repo_is_updated_with_correct_settings
-      the_repo_has_branch_protection_activated
-      the_repo_has_gh_pages_branch_protection_activated
-      the_repo_has_ci_disabled
-      the_repo_has_webhooks_configured(number_of_webhooks: 1)
-      the_repo_has_vulnerability_alerts_enabled
-      the_repo_has_automated_security_fixes_enabled
-    end
-  end
-
   describe "webhooks" do
     it "Only creates a webhook when missing" do
       given_theres_a_repo


### PR DESCRIPTION
This fixes the script to not ignore overrrides when there isn't a CI workflow job called "test". This previously worked because overrides were applied if a jenkinsfile was present. However, jenkinsfiles were removed and also that condition.