### PR TITLE
Require up-to-date branch for merge to govuk-infrastructure.

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -151,6 +151,9 @@ alphagov/govuk-fastly:
 alphagov/govuk-fastly-secrets:
   up_to_date_branches: true
 
+alphagov/govuk-infrastructure:
+  up_to_date_branches: true
+
 alphagov/imminence:
   required_status_checks:
     additional_contexts:


### PR DESCRIPTION
We're gonna need this so that we can start rolling out auto-apply safely.