### PR TITLE
Mark security checks as required

### DIFF
--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -2,7 +2,7 @@ require "base64"
 require "yaml"
 
 class ConfigureRepo
-  attr_reader :repo, :client
+  attr_reader :repo, :client, :overrides
 
   def initialize(repo, client, overrides = nil)
     @repo = repo
@@ -22,10 +22,6 @@ class ConfigureRepo
   rescue Octokit::NotFound => e
     puts "Could not find #{repo[:full_name]}. Possibly the govuk-ci user doesn't have admin access to this repo."
   end
-
-private
-
-  attr_reader :overrides
 
   def update_repo_settings
     client.edit_repository(

--- a/github/lib/configure_repo.rb
+++ b/github/lib/configure_repo.rb
@@ -93,7 +93,10 @@ class ConfigureRepo
         github_actions_test_job_name,
         *overrides
           .fetch("required_status_checks", {})
-          .fetch("additional_contexts", [])
+          .fetch("standard_contexts", []),
+        *overrides
+          .fetch("required_status_checks", {})
+          .fetch("additional_contexts", []),
       ].compact
     }
   end

--- a/github/lib/configure_repos.rb
+++ b/github/lib/configure_repos.rb
@@ -40,7 +40,7 @@ private
   end
 
   def repo_overrides
-    @repo_overrides ||= YAML.load_file("#{__dir__}/../repo_overrides.yml")["repos"]
+    @repo_overrides ||= YAML.load_file("#{__dir__}/../repo_overrides.yml", aliases: true)["repos"]
   end
 
   def client

--- a/github/lib/configure_repos.rb
+++ b/github/lib/configure_repos.rb
@@ -40,7 +40,7 @@ private
   end
 
   def repo_overrides
-    @repo_overrides ||= YAML.load_file("#{__dir__}/../repo_overrides.yml")
+    @repo_overrides ||= YAML.load_file("#{__dir__}/../repo_overrides.yml")["repos"]
   end
 
   def client

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -38,6 +38,10 @@ repos:
         - Test Ruby
         - Lint Ruby / Run RuboCop
 
+  alphagov/bulk-changer:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
   alphagov/collections:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
@@ -166,6 +170,25 @@ repos:
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml):
         # - Run Pact tests
 
+  alphagov/gds-api-adapters:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/gds-api-adapters/blob/main/.github/workflows/ci.yml):
+        # - Many different pact tests
+
+  alphagov/gds-sso:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/gds_zendesk:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/github-trello-poster:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
   alphagov/government-frontend:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
@@ -174,6 +197,14 @@ repos:
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
+
+  alphagov/govspeak:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govspeak-preview:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
 
   alphagov/govuk-aws:
     required_status_checks:
@@ -184,6 +215,14 @@ repos:
   alphagov/govuk-content-api-docs:
     need_production_access_to_merge: false
     allow_squash_merge: true
+
+  alphagov/govuk-dependabot-merger:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk-dependency-checker:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
 
   alphagov/govuk-developer-docs:
     need_production_access_to_merge: false
@@ -200,6 +239,58 @@ repos:
 
   alphagov/govuk-infrastructure:
     up_to_date_branches: true
+
+  alphagov/govuk-rota-generator:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk-saas-config:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk-sli-collector:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk_ab_testing:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk_admin_template:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk_app_config:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk_document_types:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk_message_queue_consumer:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk_personalisation:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk_publishing_components:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk_schemas:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk_sidekiq:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/govuk_test:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
 
   alphagov/hmrc-manuals-api:
     required_status_checks:
@@ -252,6 +343,10 @@ repos:
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
 
+  alphagov/markdown-toolbar-element:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
   alphagov/maslow:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
@@ -260,6 +355,22 @@ repos:
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
+
+  alphagov/miller-columns-element:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/optic14n:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/paste-html-to-govspeak:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/plek:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
 
   alphagov/publisher:
     required_status_checks:
@@ -280,6 +391,14 @@ repos:
         # - Run Content Store Pact tests
         # - Run GDS API Adapter Pact tests
 
+  alphagov/rack-logstasher:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/rails_translation_manager:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
   alphagov/release:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
@@ -298,6 +417,14 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
+
+  alphagov/rubocop-govuk:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+  
+  alphagov/seal:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
 
   alphagov/search-admin:
     required_status_checks:
@@ -357,6 +484,14 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
 
+  alphagov/siteimprove_api_client:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/slimmer:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
   alphagov/smart-answers:
     allow_squash_merge: true
     required_status_checks:
@@ -366,6 +501,14 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
+
+  alphagov/smokey:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  alphagov/special-route-publisher:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
 
   alphagov/specialist-publisher:
     required_status_checks:

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -12,7 +12,6 @@ repos:
       additional_contexts:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/account-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
         # - Run Pact tests
 
   alphagov/asset-manager:
@@ -21,7 +20,6 @@ repos:
       additional_contexts:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/asset-manager/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
         # - Run Pact tests
 
   alphagov/authenticating-proxy:
@@ -29,8 +27,6 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/authenticating-proxy/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/bouncer:
     required_status_checks:
@@ -39,8 +35,6 @@ repos:
         - Lint Ruby / Run RuboCop
         - CodeQL SAST scan
         - Dependency Review scan
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/bouncer/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/collections:
     required_status_checks:
@@ -53,7 +47,6 @@ repos:
         - Test Ruby / Run RSpec
         - Lint ERB / Lint ERB
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
         # - Run Pact tests
 
   alphagov/collections-publisher:
@@ -63,8 +56,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections-publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/contacts-admin:
     required_status_checks:
@@ -73,8 +64,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/contacts-admin/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/content-data-admin:
     required_status_checks:
@@ -83,16 +72,12 @@ repos:
         - Test Ruby
         - Lint SCSS / Run Stylelint
         - Lint JavaScript / Run Standardx
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-admin/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/content-data-api:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/content-publisher:
     required_status_checks:
@@ -102,16 +87,12 @@ repos:
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/content-store:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-store/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/content-tagger:
     required_status_checks:
@@ -120,8 +101,6 @@ repos:
         - Lint SCSS / Run Stylelint
         - Lint JavaScript / Run Standardx
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-tagger/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/data-community-tech-docs:
     need_production_access_to_merge: false
@@ -137,7 +116,6 @@ repos:
       additional_contexts:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
         # - Run Pact tests
 
   alphagov/email-alert-frontend:
@@ -148,8 +126,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-frontend/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/email-alert-service:
     required_status_checks:
@@ -158,8 +134,6 @@ repos:
         - Test Ruby / Run RSpec
         - CodeQL SAST scan
         - Dependency Review scan
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-service/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/feedback:
     required_status_checks:
@@ -169,8 +143,6 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/feedback/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/finder-frontend:
     required_status_checks:
@@ -181,8 +153,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/finder-frontend/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/frontend:
     required_status_checks:
@@ -193,7 +163,6 @@ repos:
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
         # - Run Pact tests
 
   alphagov/government-frontend:
@@ -204,8 +173,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/government-frontend/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/govuk-aws:
     required_status_checks:
@@ -238,8 +205,6 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/hmrc-manuals-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/imminence:
     required_status_checks:
@@ -249,7 +214,6 @@ repos:
         - Test Ruby
         - Lint Views
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/imminence/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
         # - Run Pact tests
 
   alphagov/link-checker-api:
@@ -258,7 +222,6 @@ repos:
       additional_contexts:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/link-checker-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
         # - Run Pact tests
 
   alphagov/local-links-manager:
@@ -269,8 +232,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Lint Views
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/local-links-manager/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/locations-api:
     required_status_checks:
@@ -278,7 +239,6 @@ repos:
       additional_contexts:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/locations-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
         # - Run Pact tests
 
   alphagov/manuals-publisher:
@@ -290,8 +250,6 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/manuals-publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/maslow:
     required_status_checks:
@@ -301,8 +259,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/maslow/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/publisher:
     required_status_checks:
@@ -312,8 +268,6 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/publishing-api:
     required_status_checks:
@@ -322,7 +276,6 @@ repos:
         - Check content schemas are built
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publishing-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
         # - Run Content Store Pact tests
         # - Run GDS API Adapter Pact tests
 
@@ -333,8 +286,6 @@ repos:
         - Test Ruby
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/release/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/router:
     required_status_checks:
@@ -346,8 +297,6 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/router-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/search-admin:
     required_status_checks:
@@ -357,8 +306,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-admin/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/search-api:
     required_status_checks:
@@ -368,8 +315,6 @@ repos:
         - Test Ruby / Run RSpec
         - CodeQL SAST scan
         - Dependency Review scan
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/search-api-v2:
     required_status_checks:
@@ -377,8 +322,6 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api-v2/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/search-v2-evaluator:
 
@@ -397,8 +340,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/service-manual-publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/short-url-manager:
     required_status_checks:
@@ -406,8 +347,6 @@ repos:
       additional_contexts:
         - Test Ruby / Run RSpec
         - Lint SCSS / Run Stylelint
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/short-url-manager/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/signon:
     required_status_checks:
@@ -417,8 +356,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/signon/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/smart-answers:
     allow_squash_merge: true
@@ -429,8 +366,6 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/smart-answers/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/specialist-publisher:
     required_status_checks:
@@ -440,8 +375,6 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/specialist-publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/static:
     required_status_checks:
@@ -451,8 +384,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/static/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/support:
     required_status_checks:
@@ -461,16 +392,12 @@ repos:
         - Test Ruby
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/support-api:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/transition:
     required_status_checks:
@@ -479,8 +406,6 @@ repos:
         - Integration tests
         - Test Ruby
         - Test JavaScript / Run Jasmine
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/transition/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/travel-advice-publisher:
     required_status_checks:
@@ -490,8 +415,6 @@ repos:
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/travel-advice-publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   alphagov/whitehall:
     required_status_checks:
@@ -504,8 +427,6 @@ repos:
         - Test Ruby / Run Minitest
         - Lint ERB / Run ERB lint
         - Prettier / Run Prettier
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/whitehall/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
 
   ##### GOVUK-SAAS-CONFIG TEST REPOS _ONLY_ BELOW THIS LINE #####
 

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -1,630 +1,631 @@
-alphagov/account-api:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/account-api/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Run Pact tests
+repos:
+  alphagov/account-api:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/account-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Run Pact tests
 
-alphagov/asset-manager:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/asset-manager/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Run Pact tests
+  alphagov/asset-manager:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/asset-manager/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Run Pact tests
 
-alphagov/authenticating-proxy:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/authenticating-proxy/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/authenticating-proxy:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/authenticating-proxy/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/bouncer:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/bouncer/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/bouncer:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/bouncer/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/collections:
-  required_status_checks:
-    additional_contexts:
-      - Integration tests
-      - Lint Ruby / Run RuboCop
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      - Security Analysis / Run Brakeman
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Lint ERB
-      # - Run Pact tests
+  alphagov/collections:
+    required_status_checks:
+      additional_contexts:
+        - Integration tests
+        - Lint Ruby / Run RuboCop
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Security Analysis / Run Brakeman
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Lint ERB
+        # - Run Pact tests
 
-alphagov/collections-publisher:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections-publisher/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/collections-publisher:
+    required_status_checks:
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections-publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/contacts-admin:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/contacts-admin/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/contacts-admin:
+    required_status_checks:
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/contacts-admin/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/content-data-api:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-api/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/content-data-api:
+    required_status_checks:
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/content-store:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-store/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/content-store:
+    required_status_checks:
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-store/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/content-tagger:
-  required_status_checks:
-    additional_contexts:
-      - Security Analysis / Run Brakeman
-      - Lint SCSS / Run Stylelint
-      - Lint Ruby / Run RuboCop
-      - Lint JavaScript / Run Standardx
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-tagger/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/content-tagger:
+    required_status_checks:
+      additional_contexts:
+        - Security Analysis / Run Brakeman
+        - Lint SCSS / Run Stylelint
+        - Lint Ruby / Run RuboCop
+        - Lint JavaScript / Run Standardx
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-tagger/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/data-community-tech-docs:
-  need_production_access_to_merge: false
-  allow_squash_merge: true
+  alphagov/data-community-tech-docs:
+    need_production_access_to_merge: false
+    allow_squash_merge: true
 
-alphagov/datagovuk-tech-docs:
-  need_production_access_to_merge: false
-  allow_squash_merge: true
+  alphagov/datagovuk-tech-docs:
+    need_production_access_to_merge: false
+    allow_squash_merge: true
 
-alphagov/email-alert-api:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-api/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Run Pact tests
+  alphagov/email-alert-api:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Run Pact tests
 
-alphagov/email-alert-frontend:
-  required_status_checks:
-    additional_contexts:
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      - Lint SCSS / Run Stylelint
-      - Lint JavaScript / Run Standardx
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-frontend/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/email-alert-frontend:
+    required_status_checks:
+      additional_contexts:
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-frontend/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/email-alert-service:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-service/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/email-alert-service:
+    required_status_checks:
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-service/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/feedback:
-  required_status_checks:
-    additional_contexts:
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/feedback/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/feedback:
+    required_status_checks:
+      additional_contexts:
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/feedback/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/frontend:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      - Security Analysis / Run Brakeman
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run Minitest
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Run Pact tests
+  alphagov/frontend:
+    required_status_checks:
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Security Analysis / Run Brakeman
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Run Pact tests
 
-alphagov/govuk-aws:
-  required_status_checks:
-    additional_contexts:
-      - Shellcheck
-      - terraform fmt
+  alphagov/govuk-aws:
+    required_status_checks:
+      additional_contexts:
+        - Shellcheck
+        - terraform fmt
 
-alphagov/govuk-content-api-docs:
-  need_production_access_to_merge: false
-  allow_squash_merge: true
+  alphagov/govuk-content-api-docs:
+    need_production_access_to_merge: false
+    allow_squash_merge: true
 
-alphagov/govuk-dns-tf:
-  up_to_date_branches: true
+  alphagov/govuk-dns-tf:
+    up_to_date_branches: true
 
-alphagov/govuk-developer-docs:
-  need_production_access_to_merge: false
-  allow_squash_merge: true
+  alphagov/govuk-developer-docs:
+    need_production_access_to_merge: false
+    allow_squash_merge: true
 
-alphagov/govuk-fastly:
-  up_to_date_branches: true
+  alphagov/govuk-fastly:
+    up_to_date_branches: true
 
-alphagov/govuk-fastly-secrets:
-  up_to_date_branches: true
+  alphagov/govuk-fastly-secrets:
+    up_to_date_branches: true
 
-alphagov/govuk-infrastructure:
-  up_to_date_branches: true
+  alphagov/govuk-infrastructure:
+    up_to_date_branches: true
 
-alphagov/imminence:
-  required_status_checks:
-    additional_contexts:
-      - Integration tests
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/imminence/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Run Pact tests
-      # - Lint Views
+  alphagov/imminence:
+    required_status_checks:
+      additional_contexts:
+        - Integration tests
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/imminence/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Run Pact tests
+        # - Lint Views
 
-alphagov/link-checker-api:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/link-checker-api/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Run Pact tests
+  alphagov/link-checker-api:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/link-checker-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Run Pact tests
 
-alphagov/local-links-manager:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      - Security Analysis / Run Brakeman
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/local-links-manager/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Lint Views
+  alphagov/local-links-manager:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Security Analysis / Run Brakeman
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/local-links-manager/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Lint Views
 
-alphagov/locations-api:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/locations-api/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Run Pact tests
+  alphagov/locations-api:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/locations-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Run Pact tests
 
-alphagov/release:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/release/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/release:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/release/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/short-url-manager:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      - Test Ruby / Run RSpec
-      - Lint SCSS / Run Stylelint
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/short-url-manager/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/short-url-manager:
+    required_status_checks:
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        - Test Ruby / Run RSpec
+        - Lint SCSS / Run Stylelint
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/short-url-manager/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/smart-answers:
-  allow_squash_merge: true
-  required_status_checks:
-    additional_contexts:
-      - Lint JavaScript / Run Standardx
-      - Security Analysis / Run Brakeman
-      - Lint SCSS / Run Stylelint
-      - Lint Ruby / Run RuboCop
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run Minitest
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/smart-answers/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/smart-answers:
+    allow_squash_merge: true
+    required_status_checks:
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Security Analysis / Run Brakeman
+        - Lint SCSS / Run Stylelint
+        - Lint Ruby / Run RuboCop
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/smart-answers/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/specialist-publisher:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Lint JavaScript / Run Standardx
-      - Security Analysis / Run Brakeman
-      - Lint SCSS / Run Stylelint
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/specialist-publisher/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/specialist-publisher:
+    required_status_checks:
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Lint JavaScript / Run Standardx
+        - Security Analysis / Run Brakeman
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/specialist-publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/support-api:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support-api/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/support-api:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/travel-advice-publisher:
-  required_status_checks:
-    additional_contexts:
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      - Lint SCSS / Run Stylelint
-      - Lint JavaScript / Run Standardx
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/travel-advice-publisher/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/travel-advice-publisher:
+    required_status_checks:
+      additional_contexts:
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/travel-advice-publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/publisher:
-  required_status_checks:
-    additional_contexts:
-      - Security Analysis / Run Brakeman
-      - Lint JavaScript / Run Standardx
-      - Lint Ruby / Run RuboCop
-      - Lint SCSS / Run Stylelint
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run Minitest
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publisher/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/publisher:
+    required_status_checks:
+      additional_contexts:
+        - Security Analysis / Run Brakeman
+        - Lint JavaScript / Run Standardx
+        - Lint Ruby / Run RuboCop
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/publishing-api:
-  required_status_checks:
-    additional_contexts:
-      - Check content schemas are built
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publishing-api/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Run Content Store Pact tests
-      # - Run GDS API Adapter Pact tests
+  alphagov/publishing-api:
+    required_status_checks:
+      additional_contexts:
+        - Check content schemas are built
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publishing-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Run Content Store Pact tests
+        # - Run GDS API Adapter Pact tests
 
-alphagov/finder-frontend:
-  required_status_checks:
-    additional_contexts:
-      - Integration tests
-      - Lint Ruby / Run RuboCop
-      - Lint SCSS / Run Stylelint
-      - Security Analysis / Run Brakeman
-      - Lint JavaScript / Run Standardx
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/finder-frontend/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/finder-frontend:
+    required_status_checks:
+      additional_contexts:
+        - Integration tests
+        - Lint Ruby / Run RuboCop
+        - Lint SCSS / Run Stylelint
+        - Security Analysis / Run Brakeman
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/finder-frontend/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/government-frontend:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      - Lint SCSS / Run Stylelint
-      - Lint JavaScript / Run Standardx
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run Minitest
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/government-frontend/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/government-frontend:
+    required_status_checks:
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/government-frontend/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/hmrc-manuals-api:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Test Ruby / Run RSpec
-      - Security Analysis / Run Brakeman
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/hmrc-manuals-api/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/hmrc-manuals-api:
+    required_status_checks:
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Test Ruby / Run RSpec
+        - Security Analysis / Run Brakeman
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/hmrc-manuals-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/manuals-publisher:
-  required_status_checks:
-    additional_contexts:
-      - Integration tests
-      - Lint JavaScript / Run Standardx
-      - Lint Ruby / Run RuboCop
-      - Lint SCSS / Run Stylelint
-      - Security Analysis / Run Brakeman
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/manuals-publisher/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/manuals-publisher:
+    required_status_checks:
+      additional_contexts:
+        - Integration tests
+        - Lint JavaScript / Run Standardx
+        - Lint Ruby / Run RuboCop
+        - Lint SCSS / Run Stylelint
+        - Security Analysis / Run Brakeman
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/manuals-publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/maslow:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      - Security Analysis / Run Brakeman
-      - Test JavaScript / Run Jasmine
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/maslow/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/maslow:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Security Analysis / Run Brakeman
+        - Test JavaScript / Run Jasmine
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/maslow/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/content-publisher:
-  required_status_checks:
-    additional_contexts:
-      - Lint SCSS / Run Stylelint
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      - Lint JavaScript / Run Standardx
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-publisher/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/content-publisher:
+    required_status_checks:
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/content-data-admin:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint SCSS / Run Stylelint
-      - Lint JavaScript / Run Standardx
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-admin/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/content-data-admin:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-admin/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/service-manual-publisher:
-  required_status_checks:
-    additional_contexts:
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      - Lint SCSS / Run Stylelint
-      - Lint JavaScript / Run Standardx
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/service-manual-publisher/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/service-manual-publisher:
+    required_status_checks:
+      additional_contexts:
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/service-manual-publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/signon:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint JavaScript / Run Standardx
-      - Lint Ruby / Run RuboCop
-      - Lint SCSS / Run Stylelint
-      - Security Analysis / Run Brakeman
-      - Test JavaScript / Run Jasmine
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/signon/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - test-ruby-matrix
+  alphagov/signon:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint JavaScript / Run Standardx
+        - Lint Ruby / Run RuboCop
+        - Lint SCSS / Run Stylelint
+        - Security Analysis / Run Brakeman
+        - Test JavaScript / Run Jasmine
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/signon/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - test-ruby-matrix
 
-alphagov/support:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/support:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/transition:
-  required_status_checks:
-    additional_contexts:
-      - Integration tests
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      - Test JavaScript / Run Jasmine
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/transition/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/transition:
+    required_status_checks:
+      additional_contexts:
+        - Integration tests
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        - Test JavaScript / Run Jasmine
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/transition/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/whitehall:
-  required_status_checks:
-    additional_contexts:
-      - Test features / Run Cucumber
-      - Lint SCSS / Run Stylelint
-      - Lint JavaScript / Run Standardx
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      - Test JavaScript / Run Jasmine
-      - Test Ruby / Run Minitest
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/whitehall/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
-      # - Lint ERB
-      # - Lint Prettier
+  alphagov/whitehall:
+    required_status_checks:
+      additional_contexts:
+        - Test features / Run Cucumber
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Lint Ruby / Run RuboCop
+        - Security Analysis / Run Brakeman
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/whitehall/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
+        # - Lint ERB
+        # - Lint Prettier
 
-alphagov/repo-for-govuk-saas-config-automated-tests:
-  up_to_date_branches: true
+  alphagov/repo-for-govuk-saas-config-automated-tests:
+    up_to_date_branches: true
 
-alphagov/router:
-  required_status_checks:
-    additional_contexts:
-     - Test Go
+  alphagov/router:
+    required_status_checks:
+      additional_contexts:
+      - Test Go
 
-alphagov/router-api:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/router-api/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/router-api:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/router-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/search-admin:
-  required_status_checks:
-    additional_contexts:
-      - Integration tests
-      - Lint Ruby / Run RuboCop
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      - Security Analysis / Run Brakeman
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-admin/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/search-admin:
+    required_status_checks:
+      additional_contexts:
+        - Integration tests
+        - Lint Ruby / Run RuboCop
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Security Analysis / Run Brakeman
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-admin/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/search-api:
-  required_status_checks:
-    additional_contexts:
-      - Check Learn to Rank dependencies
-      - Lint Ruby / Run RuboCop
-      - Test Ruby / Run RSpec
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/search-api:
+    required_status_checks:
+      additional_contexts:
+        - Check Learn to Rank dependencies
+        - Lint Ruby / Run RuboCop
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/search-api-v2:
-  required_status_checks:
-    ignore_jenkins: true
-    additional_contexts:
-      - Security Analysis / Run Brakeman
-      - Lint Ruby / Run RuboCop
-      - Test Ruby
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api-v2/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/search-api-v2:
+    required_status_checks:
+      ignore_jenkins: true
+      additional_contexts:
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Test Ruby
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api-v2/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/search-v2-evaluator:
+  alphagov/search-v2-evaluator:
 
-alphagov/search-v2-infrastructure:
-  required_status_checks:
-    ignore_jenkins: true
-    additional_contexts:
-      - lint_and_validate
-      - validate-json-schema
+  alphagov/search-v2-infrastructure:
+    required_status_checks:
+      ignore_jenkins: true
+      additional_contexts:
+        - lint_and_validate
+        - validate-json-schema
 
-alphagov/static:
-  required_status_checks:
-    additional_contexts:
-      - Test Ruby
-      - Lint Ruby / Run RuboCop
-      - Lint JavaScript / Run Standardx
-      - Lint SCSS / Run Stylelint
-      - Security Analysis / Run Brakeman
-      - Test JavaScript / Run Jasmine
-      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/static/blob/main/.github/workflows/ci.yml):
-      # - SNYK security analysis
-      # - CodeQL SAST scan
-      # - Dependency Review scan
+  alphagov/static:
+    required_status_checks:
+      additional_contexts:
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Security Analysis / Run Brakeman
+        - Test JavaScript / Run Jasmine
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/static/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - CodeQL SAST scan
+        # - Dependency Review scan
 
-alphagov/xx-test-fixture-with-allow-squash-merge:
-  allow_squash_merge: true
+  alphagov/xx-test-fixture-with-allow-squash-merge:
+    allow_squash_merge: true

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -76,12 +76,33 @@ repos:
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/contacts-admin/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
 
+  alphagov/content-data-admin:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-admin/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
   alphagov/content-data-api:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
+  alphagov/content-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-publisher/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
 
   alphagov/content-store:
@@ -151,6 +172,18 @@ repos:
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/feedback/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
 
+  alphagov/finder-frontend:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Integration tests
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/finder-frontend/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
   alphagov/frontend:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
@@ -163,6 +196,17 @@ repos:
         # - SNYK security analysis
         # - Run Pact tests
 
+  alphagov/government-frontend:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/government-frontend/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
   alphagov/govuk-aws:
     required_status_checks:
       additional_contexts:
@@ -173,12 +217,12 @@ repos:
     need_production_access_to_merge: false
     allow_squash_merge: true
 
-  alphagov/govuk-dns-tf:
-    up_to_date_branches: true
-
   alphagov/govuk-developer-docs:
     need_production_access_to_merge: false
     allow_squash_merge: true
+
+  alphagov/govuk-dns-tf:
+    up_to_date_branches: true
 
   alphagov/govuk-fastly:
     up_to_date_branches: true
@@ -188,6 +232,14 @@ repos:
 
   alphagov/govuk-infrastructure:
     up_to_date_branches: true
+
+  alphagov/hmrc-manuals-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/hmrc-manuals-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
 
   alphagov/imminence:
     required_status_checks:
@@ -229,65 +281,27 @@ repos:
         # - SNYK security analysis
         # - Run Pact tests
 
-  alphagov/release:
+  alphagov/manuals-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Integration tests
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/manuals-publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
+  alphagov/maslow:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/release/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/short-url-manager:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Test Ruby / Run RSpec
-        - Lint SCSS / Run Stylelint
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/short-url-manager/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/smart-answers:
-    allow_squash_merge: true
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Lint JavaScript / Run Standardx
-        - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
-        - Test Ruby / Run Minitest
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/smart-answers/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/specialist-publisher:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Lint JavaScript / Run Standardx
-        - Lint SCSS / Run Stylelint
-        - Test JavaScript / Run Jasmine
-        - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/specialist-publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/support-api:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/travel-advice-publisher:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Lint SCSS / Run Stylelint
-        - Lint JavaScript / Run Standardx
-        - Test JavaScript / Run Jasmine
-        - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/travel-advice-publisher/blob/main/.github/workflows/ci.yml):
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/maslow/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
 
   alphagov/publisher:
@@ -312,140 +326,15 @@ repos:
         # - Run Content Store Pact tests
         # - Run GDS API Adapter Pact tests
 
-  alphagov/finder-frontend:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Integration tests
-        - Lint SCSS / Run Stylelint
-        - Lint JavaScript / Run Standardx
-        - Test JavaScript / Run Jasmine
-        - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/finder-frontend/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/government-frontend:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Lint SCSS / Run Stylelint
-        - Lint JavaScript / Run Standardx
-        - Test JavaScript / Run Jasmine
-        - Test Ruby / Run Minitest
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/government-frontend/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/hmrc-manuals-api:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/hmrc-manuals-api/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/manuals-publisher:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Integration tests
-        - Lint JavaScript / Run Standardx
-        - Lint SCSS / Run Stylelint
-        - Test JavaScript / Run Jasmine
-        - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/manuals-publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/maslow:
+  alphagov/release:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        - Test JavaScript / Run Jasmine
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/maslow/blob/main/.github/workflows/ci.yml):
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/release/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-
-  alphagov/content-publisher:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Lint SCSS / Run Stylelint
-        - Lint JavaScript / Run Standardx
-        - Test JavaScript / Run Jasmine
-        - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/content-data-admin:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Test Ruby
-        - Lint SCSS / Run Stylelint
-        - Lint JavaScript / Run Standardx
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-admin/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/service-manual-publisher:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Lint SCSS / Run Stylelint
-        - Lint JavaScript / Run Standardx
-        - Test JavaScript / Run Jasmine
-        - Test Ruby / Run RSpec
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/service-manual-publisher/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/signon:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Test Ruby
-        - Lint JavaScript / Run Standardx
-        - Lint SCSS / Run Stylelint
-        - Test JavaScript / Run Jasmine
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/signon/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-        # - test-ruby-matrix # due to it creating dynamic job names such as `test-ruby-matrix (4, 0)` - a bit too brittle to encode here
-
-  alphagov/support:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Test Ruby
-        - Lint JavaScript / Run Standardx
-        - Lint SCSS / Run Stylelint
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/transition:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Integration tests
-        - Test Ruby
-        - Test JavaScript / Run Jasmine
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/transition/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/whitehall:
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
-      additional_contexts:
-        - Test features / Run Cucumber
-        - Lint SCSS / Run Stylelint
-        - Lint JavaScript / Run Standardx
-        - Test JavaScript / Run Jasmine
-        - Test Ruby / Run Minitest
-        - Lint ERB / Run ERB lint
-        - Prettier / Run Prettier
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/whitehall/blob/main/.github/workflows/ci.yml):
-        # - SNYK security analysis
-
-  alphagov/repo-for-govuk-saas-config-automated-tests:
-    up_to_date_branches: true
 
   alphagov/router:
     required_status_checks:
@@ -500,6 +389,61 @@ repos:
         - lint_and_validate
         - validate-json-schema
 
+  alphagov/service-manual-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/service-manual-publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
+  alphagov/short-url-manager:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby / Run RSpec
+        - Lint SCSS / Run Stylelint
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/short-url-manager/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
+  alphagov/signon:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/signon/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+        # - test-ruby-matrix # due to it creating dynamic job names such as `test-ruby-matrix (4, 0)` - a bit too brittle to encode here
+
+  alphagov/smart-answers:
+    allow_squash_merge: true
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/smart-answers/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
+  alphagov/specialist-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/specialist-publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
   alphagov/static:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
@@ -510,6 +454,64 @@ repos:
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/static/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
+
+  alphagov/support:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
+  alphagov/support-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support-api/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
+  alphagov/transition:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Integration tests
+        - Test Ruby
+        - Test JavaScript / Run Jasmine
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/transition/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
+  alphagov/travel-advice-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/travel-advice-publisher/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
+  alphagov/whitehall:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test features / Run Cucumber
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+        - Lint ERB / Run ERB lint
+        - Prettier / Run Prettier
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/whitehall/blob/main/.github/workflows/ci.yml):
+        # - SNYK security analysis
+
+  ##### GOVUK-SAAS-CONFIG TEST REPOS _ONLY_ BELOW THIS LINE #####
+
+  alphagov/repo-for-govuk-saas-config-automated-tests:
+    up_to_date_branches: true
 
   alphagov/xx-test-fixture-with-allow-squash-merge:
     allow_squash_merge: true

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -419,7 +419,6 @@ repos:
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/signon/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - test-ruby-matrix # due to it creating dynamic job names such as `test-ruby-matrix (4, 0)` - a bit too brittle to encode here
 
   alphagov/smart-answers:
     allow_squash_merge: true

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -51,9 +51,9 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
+        - Lint ERB / Lint ERB
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - Lint ERB
         # - Run Pact tests
 
   alphagov/collections-publisher:
@@ -195,10 +195,10 @@ repos:
       additional_contexts:
         - Integration tests
         - Test Ruby
+        - Lint Views
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/imminence/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - Run Pact tests
-        # - Lint Views
 
   alphagov/link-checker-api:
     required_status_checks:
@@ -216,9 +216,9 @@ repos:
         - Test Ruby
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
+        - Lint Views
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/local-links-manager/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - Lint Views
 
   alphagov/locations-api:
     required_status_checks:
@@ -408,7 +408,7 @@ repos:
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/signon/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - test-ruby-matrix
+        # - test-ruby-matrix # due to it creating dynamic job names such as `test-ruby-matrix (4, 0)` - a bit too brittle to encode here
 
   alphagov/support:
     required_status_checks:
@@ -439,10 +439,10 @@ repos:
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
+        - Lint ERB / Run ERB lint
+        - Prettier / Run Prettier
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/whitehall/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - Lint ERB
-        # - Lint Prettier
 
   alphagov/repo-for-govuk-saas-config-automated-tests:
     up_to_date_branches: true

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -1,9 +1,12 @@
 access_levels:
-  standard_govuk_rails_checks: &standard_govuk_rails_checks
-    - Lint Ruby / Run RuboCop
-    - Security Analysis / Run Brakeman
+  standard_security_checks: &standard_security_checks
     - CodeQL SAST scan
     - Dependency Review scan
+  standard_govuk_rails_checks: &standard_govuk_rails_checks
+    - CodeQL SAST scan
+    - Dependency Review scan
+    - Lint Ruby / Run RuboCop
+    - Security Analysis / Run Brakeman
 
 repos:
   alphagov/account-api:
@@ -30,11 +33,10 @@ repos:
 
   alphagov/bouncer:
     required_status_checks:
+      standard_contexts: *standard_security_checks
       additional_contexts:
         - Test Ruby
         - Lint Ruby / Run RuboCop
-        - CodeQL SAST scan
-        - Dependency Review scan
 
   alphagov/collections:
     required_status_checks:
@@ -129,11 +131,10 @@ repos:
 
   alphagov/email-alert-service:
     required_status_checks:
+      standard_contexts: *standard_security_checks
       additional_contexts:
         - Lint Ruby / Run RuboCop
         - Test Ruby / Run RSpec
-        - CodeQL SAST scan
-        - Dependency Review scan
 
   alphagov/feedback:
     required_status_checks:
@@ -309,12 +310,11 @@ repos:
 
   alphagov/search-api:
     required_status_checks:
+      standard_contexts: *standard_security_checks
       additional_contexts:
         - Check Learn to Rank dependencies
         - Lint Ruby / Run RuboCop
         - Test Ruby / Run RSpec
-        - CodeQL SAST scan
-        - Dependency Review scan
 
   alphagov/search-api-v2:
     required_status_checks:

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -1,10 +1,14 @@
+access_levels:
+  standard_govuk_rails_checks: &standard_govuk_rails_checks
+    - Lint Ruby / Run RuboCop
+    - Security Analysis / Run Brakeman
+
 repos:
   alphagov/account-api:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/account-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -13,10 +17,9 @@ repos:
 
   alphagov/asset-manager:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/asset-manager/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -25,10 +28,9 @@ repos:
 
   alphagov/authenticating-proxy:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/authenticating-proxy/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -46,12 +48,11 @@ repos:
 
   alphagov/collections:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Integration tests
-        - Lint Ruby / Run RuboCop
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        - Security Analysis / Run Brakeman
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/ci.yml):
@@ -63,9 +64,8 @@ repos:
 
   alphagov/collections-publisher:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test Ruby / Run RSpec
@@ -76,9 +76,8 @@ repos:
 
   alphagov/contacts-admin:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test Ruby / Run RSpec
@@ -89,9 +88,8 @@ repos:
 
   alphagov/content-data-api:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
@@ -100,9 +98,8 @@ repos:
 
   alphagov/content-store:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-store/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
@@ -111,10 +108,9 @@ repos:
 
   alphagov/content-tagger:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Security Analysis / Run Brakeman
         - Lint SCSS / Run Stylelint
-        - Lint Ruby / Run RuboCop
         - Lint JavaScript / Run Standardx
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-tagger/blob/main/.github/workflows/ci.yml):
@@ -132,10 +128,9 @@ repos:
 
   alphagov/email-alert-api:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -144,9 +139,8 @@ repos:
 
   alphagov/email-alert-frontend:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         - Lint SCSS / Run Stylelint
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
@@ -168,9 +162,8 @@ repos:
 
   alphagov/feedback:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
@@ -182,11 +175,10 @@ repos:
 
   alphagov/frontend:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Lint Ruby / Run RuboCop
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        - Security Analysis / Run Brakeman
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml):
@@ -223,11 +215,10 @@ repos:
 
   alphagov/imminence:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Integration tests
         - Test Ruby
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/imminence/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -237,10 +228,9 @@ repos:
 
   alphagov/link-checker-api:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/link-checker-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -249,12 +239,11 @@ repos:
 
   alphagov/local-links-manager:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Lint Ruby / Run RuboCop
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        - Security Analysis / Run Brakeman
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/local-links-manager/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -263,10 +252,9 @@ repos:
 
   alphagov/locations-api:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/locations-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -275,10 +263,9 @@ repos:
 
   alphagov/release:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/release/blob/main/.github/workflows/ci.yml):
@@ -288,9 +275,8 @@ repos:
 
   alphagov/short-url-manager:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         - Test Ruby / Run RSpec
         - Lint SCSS / Run Stylelint
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/short-url-manager/blob/main/.github/workflows/ci.yml):
@@ -301,11 +287,10 @@ repos:
   alphagov/smart-answers:
     allow_squash_merge: true
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Lint JavaScript / Run Standardx
-        - Security Analysis / Run Brakeman
         - Lint SCSS / Run Stylelint
-        - Lint Ruby / Run RuboCop
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/smart-answers/blob/main/.github/workflows/ci.yml):
@@ -315,10 +300,9 @@ repos:
 
   alphagov/specialist-publisher:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Lint Ruby / Run RuboCop
         - Lint JavaScript / Run Standardx
-        - Security Analysis / Run Brakeman
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
@@ -329,10 +313,9 @@ repos:
 
   alphagov/support-api:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -340,9 +323,8 @@ repos:
 
   alphagov/travel-advice-publisher:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         - Lint SCSS / Run Stylelint
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
@@ -354,10 +336,9 @@ repos:
 
   alphagov/publisher:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Security Analysis / Run Brakeman
         - Lint JavaScript / Run Standardx
-        - Lint Ruby / Run RuboCop
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
@@ -368,11 +349,10 @@ repos:
 
   alphagov/publishing-api:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Check content schemas are built
         - Test Ruby
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publishing-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -382,11 +362,10 @@ repos:
 
   alphagov/finder-frontend:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Integration tests
-        - Lint Ruby / Run RuboCop
         - Lint SCSS / Run Stylelint
-        - Security Analysis / Run Brakeman
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
@@ -397,9 +376,8 @@ repos:
 
   alphagov/government-frontend:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         - Lint SCSS / Run Stylelint
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
@@ -411,10 +389,9 @@ repos:
 
   alphagov/hmrc-manuals-api:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Lint Ruby / Run RuboCop
         - Test Ruby / Run RSpec
-        - Security Analysis / Run Brakeman
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/hmrc-manuals-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -422,12 +399,11 @@ repos:
 
   alphagov/manuals-publisher:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Integration tests
         - Lint JavaScript / Run Standardx
-        - Lint Ruby / Run RuboCop
         - Lint SCSS / Run Stylelint
-        - Security Analysis / Run Brakeman
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/manuals-publisher/blob/main/.github/workflows/ci.yml):
@@ -437,12 +413,11 @@ repos:
 
   alphagov/maslow:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Lint Ruby / Run RuboCop
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        - Security Analysis / Run Brakeman
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/maslow/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
@@ -451,10 +426,9 @@ repos:
 
   alphagov/content-publisher:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Lint SCSS / Run Stylelint
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
@@ -465,12 +439,11 @@ repos:
 
   alphagov/content-data-admin:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
         - Lint SCSS / Run Stylelint
         - Lint JavaScript / Run Standardx
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-admin/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -478,9 +451,8 @@ repos:
 
   alphagov/service-manual-publisher:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         - Lint SCSS / Run Stylelint
         - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
@@ -492,12 +464,11 @@ repos:
 
   alphagov/signon:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
         - Lint JavaScript / Run Standardx
-        - Lint Ruby / Run RuboCop
         - Lint SCSS / Run Stylelint
-        - Security Analysis / Run Brakeman
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/signon/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
@@ -507,12 +478,11 @@ repos:
 
   alphagov/support:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -520,11 +490,10 @@ repos:
 
   alphagov/transition:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Integration tests
         - Test Ruby
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/transition/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
@@ -533,12 +502,11 @@ repos:
 
   alphagov/whitehall:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test features / Run Cucumber
         - Lint SCSS / Run Stylelint
         - Lint JavaScript / Run Standardx
-        - Lint Ruby / Run RuboCop
-        - Security Analysis / Run Brakeman
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/whitehall/blob/main/.github/workflows/ci.yml):
@@ -558,10 +526,9 @@ repos:
 
   alphagov/router-api:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/router-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
         # - CodeQL SAST scan
@@ -569,12 +536,11 @@ repos:
 
   alphagov/search-admin:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Integration tests
-        - Lint Ruby / Run RuboCop
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        - Security Analysis / Run Brakeman
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-admin/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
@@ -595,9 +561,8 @@ repos:
   alphagov/search-api-v2:
     required_status_checks:
       ignore_jenkins: true
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api-v2/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
@@ -615,12 +580,11 @@ repos:
 
   alphagov/static:
     required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        - Lint Ruby / Run RuboCop
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
-        - Security Analysis / Run Brakeman
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/static/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -419,15 +419,6 @@ alphagov/hmrc-manuals-api:
       # - CodeQL SAST scan
       # - Dependency Review scan
 
-alphagov/licence-finder:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Security Analysis / Run Brakeman
-      - Test Ruby / Run RSpec
-
-alphagov/manuals-frontend:
-
 alphagov/manuals-publisher:
   required_status_checks:
     additional_contexts:
@@ -457,13 +448,6 @@ alphagov/maslow:
       # - CodeQL SAST scan
       # - Dependency Review scan
 
-alphagov/info-frontend:
-  required_status_checks:
-    additional_contexts:
-      - Lint Ruby / Run RuboCop
-      - Test Ruby / Run RSpec
-      - Security Analysis / Run Brakeman
-
 alphagov/content-publisher:
   required_status_checks:
     additional_contexts:
@@ -491,8 +475,6 @@ alphagov/content-data-admin:
       # - CodeQL SAST scan
       # - Dependency Review scan
 
-alphagov/service-manual-frontend:
-
 alphagov/service-manual-publisher:
   required_status_checks:
     additional_contexts:
@@ -506,8 +488,6 @@ alphagov/service-manual-publisher:
       # - SNYK security analysis
       # - CodeQL SAST scan
       # - Dependency Review scan
-
-alphagov/sidekiq-monitoring:
 
 alphagov/signon:
   required_status_checks:

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -4,6 +4,11 @@ alphagov/account-api:
       - Test Ruby
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/account-api/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Run Pact tests
 
 alphagov/asset-manager:
   required_status_checks:
@@ -11,6 +16,11 @@ alphagov/asset-manager:
       - Test Ruby
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/asset-manager/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Run Pact tests
 
 alphagov/authenticating-proxy:
   required_status_checks:
@@ -18,12 +28,20 @@ alphagov/authenticating-proxy:
       - Test Ruby
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/authenticating-proxy/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/bouncer:
   required_status_checks:
     additional_contexts:
       - Test Ruby
       - Lint Ruby / Run RuboCop
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/bouncer/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/collections:
   required_status_checks:
@@ -35,6 +53,12 @@ alphagov/collections:
       - Security Analysis / Run Brakeman
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Lint ERB
+      # - Run Pact tests
 
 alphagov/collections-publisher:
   required_status_checks:
@@ -44,6 +68,10 @@ alphagov/collections-publisher:
       - Lint JavaScript / Run Standardx
       - Lint SCSS / Run Stylelint
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections-publisher/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/contacts-admin:
   required_status_checks:
@@ -53,6 +81,10 @@ alphagov/contacts-admin:
       - Lint JavaScript / Run Standardx
       - Lint SCSS / Run Stylelint
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/contacts-admin/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/content-data-api:
   required_status_checks:
@@ -60,6 +92,10 @@ alphagov/content-data-api:
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-api/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/content-store:
   required_status_checks:
@@ -67,6 +103,10 @@ alphagov/content-store:
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-store/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/content-tagger:
   required_status_checks:
@@ -76,6 +116,10 @@ alphagov/content-tagger:
       - Lint Ruby / Run RuboCop
       - Lint JavaScript / Run Standardx
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-tagger/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/data-community-tech-docs:
   need_production_access_to_merge: false
@@ -91,6 +135,11 @@ alphagov/email-alert-api:
       - Test Ruby
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-api/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Run Pact tests
 
 alphagov/email-alert-frontend:
   required_status_checks:
@@ -101,12 +150,20 @@ alphagov/email-alert-frontend:
       - Lint JavaScript / Run Standardx
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-frontend/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/email-alert-service:
   required_status_checks:
     additional_contexts:
       - Lint Ruby / Run RuboCop
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-service/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/feedback:
   required_status_checks:
@@ -117,6 +174,10 @@ alphagov/feedback:
       - Lint SCSS / Run Stylelint
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/feedback/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/frontend:
   required_status_checks:
@@ -127,6 +188,11 @@ alphagov/frontend:
       - Security Analysis / Run Brakeman
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run Minitest
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Run Pact tests
 
 alphagov/govuk-aws:
   required_status_checks:
@@ -161,6 +227,12 @@ alphagov/imminence:
       - Test Ruby
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/imminence/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Run Pact tests
+      # - Lint Views
 
 alphagov/link-checker-api:
   required_status_checks:
@@ -168,6 +240,11 @@ alphagov/link-checker-api:
       - Test Ruby
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/link-checker-api/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Run Pact tests
 
 alphagov/local-links-manager:
   required_status_checks:
@@ -177,6 +254,11 @@ alphagov/local-links-manager:
       - Lint JavaScript / Run Standardx
       - Lint SCSS / Run Stylelint
       - Security Analysis / Run Brakeman
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/local-links-manager/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Lint Views
 
 alphagov/locations-api:
   required_status_checks:
@@ -184,6 +266,11 @@ alphagov/locations-api:
       - Test Ruby
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/locations-api/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Run Pact tests
 
 alphagov/release:
   required_status_checks:
@@ -193,6 +280,10 @@ alphagov/release:
       - Security Analysis / Run Brakeman
       - Lint JavaScript / Run Standardx
       - Lint SCSS / Run Stylelint
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/release/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/short-url-manager:
   required_status_checks:
@@ -201,6 +292,10 @@ alphagov/short-url-manager:
       - Security Analysis / Run Brakeman
       - Test Ruby / Run RSpec
       - Lint SCSS / Run Stylelint
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/short-url-manager/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/smart-answers:
   allow_squash_merge: true
@@ -212,6 +307,10 @@ alphagov/smart-answers:
       - Lint Ruby / Run RuboCop
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run Minitest
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/smart-answers/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/specialist-publisher:
   required_status_checks:
@@ -222,6 +321,10 @@ alphagov/specialist-publisher:
       - Lint SCSS / Run Stylelint
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/specialist-publisher/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/support-api:
   required_status_checks:
@@ -229,6 +332,10 @@ alphagov/support-api:
       - Test Ruby
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support-api/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/travel-advice-publisher:
   required_status_checks:
@@ -239,6 +346,10 @@ alphagov/travel-advice-publisher:
       - Lint JavaScript / Run Standardx
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/travel-advice-publisher/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/publisher:
   required_status_checks:
@@ -249,6 +360,10 @@ alphagov/publisher:
       - Lint SCSS / Run Stylelint
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run Minitest
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publisher/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/publishing-api:
   required_status_checks:
@@ -257,6 +372,12 @@ alphagov/publishing-api:
       - Test Ruby
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publishing-api/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Run Content Store Pact tests
+      # - Run GDS API Adapter Pact tests
 
 alphagov/finder-frontend:
   required_status_checks:
@@ -268,6 +389,10 @@ alphagov/finder-frontend:
       - Lint JavaScript / Run Standardx
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/finder-frontend/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/government-frontend:
   required_status_checks:
@@ -278,6 +403,10 @@ alphagov/government-frontend:
       - Lint JavaScript / Run Standardx
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run Minitest
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/government-frontend/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/hmrc-manuals-api:
   required_status_checks:
@@ -285,6 +414,10 @@ alphagov/hmrc-manuals-api:
       - Lint Ruby / Run RuboCop
       - Test Ruby / Run RSpec
       - Security Analysis / Run Brakeman
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/hmrc-manuals-api/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/licence-finder:
   required_status_checks:
@@ -305,6 +438,10 @@ alphagov/manuals-publisher:
       - Security Analysis / Run Brakeman
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/manuals-publisher/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/maslow:
   required_status_checks:
@@ -315,6 +452,10 @@ alphagov/maslow:
       - Lint SCSS / Run Stylelint
       - Security Analysis / Run Brakeman
       - Test JavaScript / Run Jasmine
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/maslow/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/info-frontend:
   required_status_checks:
@@ -332,6 +473,10 @@ alphagov/content-publisher:
       - Lint JavaScript / Run Standardx
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-publisher/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/content-data-admin:
   required_status_checks:
@@ -341,6 +486,10 @@ alphagov/content-data-admin:
       - Lint JavaScript / Run Standardx
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-admin/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/service-manual-frontend:
 
@@ -353,6 +502,10 @@ alphagov/service-manual-publisher:
       - Lint JavaScript / Run Standardx
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/service-manual-publisher/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/sidekiq-monitoring:
 
@@ -365,6 +518,11 @@ alphagov/signon:
       - Lint SCSS / Run Stylelint
       - Security Analysis / Run Brakeman
       - Test JavaScript / Run Jasmine
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/signon/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - test-ruby-matrix
 
 alphagov/support:
   required_status_checks:
@@ -374,6 +532,10 @@ alphagov/support:
       - Lint SCSS / Run Stylelint
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/transition:
   required_status_checks:
@@ -383,6 +545,10 @@ alphagov/transition:
       - Lint Ruby / Run RuboCop
       - Security Analysis / Run Brakeman
       - Test JavaScript / Run Jasmine
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/transition/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/whitehall:
   required_status_checks:
@@ -394,6 +560,12 @@ alphagov/whitehall:
       - Security Analysis / Run Brakeman
       - Test JavaScript / Run Jasmine
       - Test Ruby / Run Minitest
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/whitehall/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
+      # - Lint ERB
+      # - Lint Prettier
 
 alphagov/repo-for-govuk-saas-config-automated-tests:
   up_to_date_branches: true
@@ -409,6 +581,10 @@ alphagov/router-api:
       - Test Ruby
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/router-api/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/search-admin:
   required_status_checks:
@@ -419,6 +595,10 @@ alphagov/search-admin:
       - Lint SCSS / Run Stylelint
       - Security Analysis / Run Brakeman
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-admin/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/search-api:
   required_status_checks:
@@ -426,6 +606,10 @@ alphagov/search-api:
       - Check Learn to Rank dependencies
       - Lint Ruby / Run RuboCop
       - Test Ruby / Run RSpec
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/search-api-v2:
   required_status_checks:
@@ -434,6 +618,10 @@ alphagov/search-api-v2:
       - Security Analysis / Run Brakeman
       - Lint Ruby / Run RuboCop
       - Test Ruby
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api-v2/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/search-v2-evaluator:
 
@@ -453,6 +641,10 @@ alphagov/static:
       - Lint SCSS / Run Stylelint
       - Security Analysis / Run Brakeman
       - Test JavaScript / Run Jasmine
+      # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/static/blob/main/.github/workflows/ci.yml):
+      # - SNYK security analysis
+      # - CodeQL SAST scan
+      # - Dependency Review scan
 
 alphagov/xx-test-fixture-with-allow-squash-merge:
   allow_squash_merge: true

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -2,6 +2,8 @@ access_levels:
   standard_govuk_rails_checks: &standard_govuk_rails_checks
     - Lint Ruby / Run RuboCop
     - Security Analysis / Run Brakeman
+    - CodeQL SAST scan
+    - Dependency Review scan
 
 repos:
   alphagov/account-api:
@@ -11,8 +13,6 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/account-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Run Pact tests
 
   alphagov/asset-manager:
@@ -22,8 +22,6 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/asset-manager/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Run Pact tests
 
   alphagov/authenticating-proxy:
@@ -33,18 +31,16 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/authenticating-proxy/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/bouncer:
     required_status_checks:
       additional_contexts:
         - Test Ruby
         - Lint Ruby / Run RuboCop
+        - CodeQL SAST scan
+        - Dependency Review scan
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/bouncer/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/collections:
     required_status_checks:
@@ -57,8 +53,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Lint ERB
         # - Run Pact tests
 
@@ -71,8 +65,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections-publisher/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/contacts-admin:
     required_status_checks:
@@ -83,8 +75,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/contacts-admin/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/content-data-api:
     required_status_checks:
@@ -93,8 +83,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/content-store:
     required_status_checks:
@@ -103,8 +91,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-store/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/content-tagger:
     required_status_checks:
@@ -115,8 +101,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-tagger/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/data-community-tech-docs:
     need_production_access_to_merge: false
@@ -133,8 +117,6 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Run Pact tests
 
   alphagov/email-alert-frontend:
@@ -147,18 +129,16 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-frontend/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/email-alert-service:
     required_status_checks:
       additional_contexts:
         - Lint Ruby / Run RuboCop
         - Test Ruby / Run RSpec
+        - CodeQL SAST scan
+        - Dependency Review scan
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-service/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/feedback:
     required_status_checks:
@@ -170,8 +150,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/feedback/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/frontend:
     required_status_checks:
@@ -183,8 +161,6 @@ repos:
         - Test Ruby / Run Minitest
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Run Pact tests
 
   alphagov/govuk-aws:
@@ -221,8 +197,6 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/imminence/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Run Pact tests
         # - Lint Views
 
@@ -233,8 +207,6 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/link-checker-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Run Pact tests
 
   alphagov/local-links-manager:
@@ -246,8 +218,6 @@ repos:
         - Lint SCSS / Run Stylelint
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/local-links-manager/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Lint Views
 
   alphagov/locations-api:
@@ -257,8 +227,6 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/locations-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Run Pact tests
 
   alphagov/release:
@@ -270,8 +238,6 @@ repos:
         - Lint SCSS / Run Stylelint
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/release/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/short-url-manager:
     required_status_checks:
@@ -281,8 +247,6 @@ repos:
         - Lint SCSS / Run Stylelint
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/short-url-manager/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/smart-answers:
     allow_squash_merge: true
@@ -295,8 +259,6 @@ repos:
         - Test Ruby / Run Minitest
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/smart-answers/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/specialist-publisher:
     required_status_checks:
@@ -308,8 +270,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/specialist-publisher/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/support-api:
     required_status_checks:
@@ -318,8 +278,6 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/travel-advice-publisher:
     required_status_checks:
@@ -331,8 +289,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/travel-advice-publisher/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/publisher:
     required_status_checks:
@@ -344,8 +300,6 @@ repos:
         - Test Ruby / Run Minitest
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publisher/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/publishing-api:
     required_status_checks:
@@ -355,8 +309,6 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publishing-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Run Content Store Pact tests
         # - Run GDS API Adapter Pact tests
 
@@ -371,8 +323,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/finder-frontend/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/government-frontend:
     required_status_checks:
@@ -384,8 +334,6 @@ repos:
         - Test Ruby / Run Minitest
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/government-frontend/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/hmrc-manuals-api:
     required_status_checks:
@@ -394,8 +342,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/hmrc-manuals-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/manuals-publisher:
     required_status_checks:
@@ -408,8 +354,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/manuals-publisher/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/maslow:
     required_status_checks:
@@ -421,8 +365,6 @@ repos:
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/maslow/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/content-publisher:
     required_status_checks:
@@ -434,8 +376,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-publisher/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/content-data-admin:
     required_status_checks:
@@ -446,8 +386,6 @@ repos:
         - Lint JavaScript / Run Standardx
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/content-data-admin/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/service-manual-publisher:
     required_status_checks:
@@ -459,8 +397,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/service-manual-publisher/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/signon:
     required_status_checks:
@@ -472,8 +408,6 @@ repos:
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/signon/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - test-ruby-matrix
 
   alphagov/support:
@@ -485,8 +419,6 @@ repos:
         - Lint SCSS / Run Stylelint
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/support/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/transition:
     required_status_checks:
@@ -497,8 +429,6 @@ repos:
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/transition/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/whitehall:
     required_status_checks:
@@ -511,8 +441,6 @@ repos:
         - Test Ruby / Run Minitest
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/whitehall/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
         # - Lint ERB
         # - Lint Prettier
 
@@ -531,8 +459,6 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/router-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/search-admin:
     required_status_checks:
@@ -544,8 +470,6 @@ repos:
         - Test Ruby / Run RSpec
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-admin/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/search-api:
     required_status_checks:
@@ -553,10 +477,10 @@ repos:
         - Check Learn to Rank dependencies
         - Lint Ruby / Run RuboCop
         - Test Ruby / Run RSpec
+        - CodeQL SAST scan
+        - Dependency Review scan
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/search-api-v2:
     required_status_checks:
@@ -566,8 +490,6 @@ repos:
         - Test Ruby
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/search-api-v2/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/search-v2-evaluator:
 
@@ -588,8 +510,6 @@ repos:
         - Test JavaScript / Run Jasmine
         # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/static/blob/main/.github/workflows/ci.yml):
         # - SNYK security analysis
-        # - CodeQL SAST scan
-        # - Dependency Review scan
 
   alphagov/xx-test-fixture-with-allow-squash-merge:
     allow_squash_merge: true

--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -1,10 +1,10 @@
 access_levels:
   standard_security_checks: &standard_security_checks
-    - CodeQL SAST scan
-    - Dependency Review scan
+    - CodeQL SAST scan / Analyze
+    - Dependency Review scan / dependency-review-pr
   standard_govuk_rails_checks: &standard_govuk_rails_checks
-    - CodeQL SAST scan
-    - Dependency Review scan
+    - CodeQL SAST scan / Analyze
+    - Dependency Review scan / dependency-review-pr
     - Lint Ruby / Run RuboCop
     - Security Analysis / Run Brakeman
 

--- a/github/spec/configure_repo_spec.rb
+++ b/github/spec/configure_repo_spec.rb
@@ -1,0 +1,76 @@
+require_relative "./spec_helper"
+require_relative "../lib/configure_repo"
+
+RSpec.describe ConfigureRepo do
+  describe "required_status_checks" do
+    let(:repo) {  { full_name: "alphagov/foo" } }
+    let(:client) { nil }
+
+    it "should return no additional contexts if no overrides provided" do
+      overrides = {}
+      configured_repo = ConfigureRepo.new(repo, client, overrides)
+      allow(configured_repo).to receive(:github_actions_test_job_name).and_return(nil)
+
+      expect(configured_repo.required_status_checks).to eq({
+        strict: false,
+        contexts: [],
+      })
+    end
+
+    it "should set `strict: true` if up_to_date_branches is set to `true`" do
+      overrides = {
+        "up_to_date_branches" => true,
+      }
+      configured_repo = ConfigureRepo.new(repo, client, overrides)
+      allow(configured_repo).to receive(:github_actions_test_job_name).and_return(nil)
+
+      expect(configured_repo.required_status_checks).to eq({
+        strict: true,
+        contexts: [],
+      })
+    end
+
+    it "should return additional_contexts if provided" do
+      overrides = {
+        "required_status_checks" => {
+          "additional_contexts" => [
+            "bar",
+            "baz",
+          ]
+        }
+      }
+      configured_repo = ConfigureRepo.new(repo, client, overrides)
+      allow(configured_repo).to receive(:github_actions_test_job_name).and_return(nil)
+
+      expect(configured_repo.required_status_checks).to eq({
+        strict: false,
+        contexts: [
+          "bar",
+          "baz",
+        ],
+      })
+    end
+
+    it "should include the GitHub Actions test job name if it exists" do
+      overrides = {
+        "required_status_checks" => {
+          "additional_contexts" => [
+            "bar",
+            "baz",
+          ]
+        }
+      }
+      configured_repo = ConfigureRepo.new(repo, client, overrides)
+      allow(configured_repo).to receive(:github_actions_test_job_name).and_return("test")
+
+      expect(configured_repo.required_status_checks).to eq({
+        strict: false,
+        contexts: [
+          "test",
+          "bar",
+          "baz",
+        ],
+      })
+    end
+  end
+end

--- a/github/spec/configure_repo_spec.rb
+++ b/github/spec/configure_repo_spec.rb
@@ -51,6 +51,29 @@ RSpec.describe ConfigureRepo do
       })
     end
 
+    it "should include standard_contexts if provided" do
+      overrides = {
+        "required_status_checks" => {
+          "standard_contexts" => [
+            "foo",
+          ],
+          "additional_contexts" => [
+            "bar",
+          ],
+        }
+      }
+      configured_repo = ConfigureRepo.new(repo, client, overrides)
+      allow(configured_repo).to receive(:github_actions_test_job_name).and_return(nil)
+
+      expect(configured_repo.required_status_checks).to eq({
+        strict: false,
+        contexts: [
+          "foo",
+          "bar",
+        ],
+      })
+    end
+
     it "should include the GitHub Actions test job name if it exists" do
       overrides = {
         "required_status_checks" => {

--- a/github/spec/features/configure_repos_spec.rb
+++ b/github/spec/features/configure_repos_spec.rb
@@ -7,13 +7,13 @@ require 'yaml'
 RSpec.describe ConfigureRepos do
   context "when a repo uses GitHub Actions for CI" do
     it "Updates a repo" do
-      given_theres_a_repo(full_name: "alphagov/rubocop-govuk")
-      and_the_repo_uses_github_actions_for_test(full_name: "alphagov/rubocop-govuk")
+      given_theres_a_repo(full_name: "alphagov/foo")
+      and_the_repo_uses_github_actions_for_test(full_name: "alphagov/foo")
       when_the_script_runs
       the_repo_is_updated_with_correct_settings
       the_repo_has_branch_protection_activated
       the_repo_has_gh_pages_branch_protection_activated
-      the_repo_has_ci_enabled(full_name: "alphagov/rubocop-govuk", providers: ["github_actions"])
+      the_repo_has_ci_enabled(full_name: "alphagov/foo", providers: ["github_actions"])
       the_repo_has_webhooks_configured(number_of_webhooks: 1)
       the_repo_has_vulnerability_alerts_enabled
       the_repo_has_automated_security_fixes_enabled
@@ -42,10 +42,10 @@ RSpec.describe ConfigureRepos do
 
     context "and the test job has a custom name" do
       it "Uses the custom name" do
-        given_theres_a_repo(full_name: "alphagov/rubocop-govuk")
-        and_the_repo_uses_github_actions_for_test(full_name: "alphagov/rubocop-govuk", job_name: "Run tests")
+        given_theres_a_repo(full_name: "alphagov/foo")
+        and_the_repo_uses_github_actions_for_test(full_name: "alphagov/foo", job_name: "Run tests")
         when_the_script_runs
-        the_repo_has_ci_enabled(full_name: "alphagov/rubocop-govuk", providers: ["github_actions"], github_actions: ["Run tests"])
+        the_repo_has_ci_enabled(full_name: "alphagov/foo", providers: ["github_actions"], github_actions: ["Run tests"])
         the_repo_has_vulnerability_alerts_enabled
         the_repo_has_automated_security_fixes_enabled
       end


### PR DESCRIPTION
- Cleans up overrides config (reorder alphabetically, reference 'aliases' of grouped status checks, etc)
- Adds missing repos that require overrides
- Makes the "CodeQL SAST scan" and "Dependency Review scan" jobs required, enabling RFC-167

Tested running the action: https://github.com/alphagov/govuk-saas-config/actions/runs/8646931233

Trello: https://trello.com/c/3CYpdFw4/3480-set-stricter-branch-protection-defaults