### PR TITLE
Remove Learn to Rank check

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -445,7 +445,7 @@ repos:
   alphagov/rubocop-govuk:
     required_status_checks:
       standard_contexts: *standard_security_checks
-  
+
   alphagov/seal:
     required_status_checks:
       standard_contexts: *standard_security_checks
@@ -462,7 +462,6 @@ repos:
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
-        - Check Learn to Rank dependencies
         - Lint Ruby / Run RuboCop
         - Test Ruby / Run RSpec
 


### PR DESCRIPTION
Learn to Rank has been removed, so [this check no longer exists](https://github.com/alphagov/search-api/commit/3bdbbb910205c1abde3647f01a6687e9d203e463)