### PR TITLE
Remove `search-v2-infrastructure` status requirement

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -479,7 +479,6 @@ repos:
       ignore_jenkins: true
       additional_contexts:
         - lint_and_validate
-        - validate-json-schema
 
   alphagov/service-manual-publisher:
     required_status_checks:


### PR DESCRIPTION
The "validate-json-schema" Github action is being removed from this repo, and therefore no longer should be a required step.

see https://github.com/alphagov/search-v2-infrastructure/pull/276