### PR TITLE
Add search-analytics as an ignored repo

### DIFF
--- a/github/ignored_repos.yml
+++ b/github/ignored_repos.yml
@@ -1,4 +1,5 @@
 # Repos that should not be auto-configured
+- alphagov/search-analytics
 
 # Ignored for the specs
 - alphagov/ignored-for-test


### PR DESCRIPTION
We don't want dependabot security PRs for Search Analytics as they are quite dangerous to merge.

The useful life of Search Analytics is very short now (depends on universal analytics that are turned off July 1st) so it seems to be of low consequence to ignore this from all config.