### PR TITLE
Remove special-route-publisher (now retired)

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -530,10 +530,6 @@ repos:
     required_status_checks:
       standard_contexts: *standard_security_checks
 
-  alphagov/special-route-publisher:
-    required_status_checks:
-      standard_contexts: *standard_security_checks
-
   alphagov/specialist-publisher:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks


### PR DESCRIPTION
Special Route Publisher retired as of: https://github.com/alphagov/special-route-publisher/pull/353

https://trello.com/c/9rOxWNnD/396-retire-special-route-publisher